### PR TITLE
Add Moroccan-themed Astra overrides for hotel CPT

### DIFF
--- a/archive-lbhotel_hotel.php
+++ b/archive-lbhotel_hotel.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Archive template for Le Bon Hotel listings.
+ * Astra archive override for Le Bon Hotel listings.
  *
- * Place this file inside your active theme to customize the archive view for
- * the `lbhotel_hotel` custom post type.
+ * Place this file in your active theme (or child theme) to override the archive
+ * view for the `lbhotel_hotel` custom post type provided by the Le Bon Hotel
+ * plugin.
  *
  * @package LeBonHotel
  */
@@ -12,207 +13,143 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-get_header();
+$theme_directory = get_stylesheet_directory_uri();
 
-$search_term = isset( $_GET['lbhotel_search'] ) ? sanitize_text_field( wp_unslash( $_GET['lbhotel_search'] ) ) : '';
-$distance     = isset( $_GET['lbhotel_distance'] ) ? sanitize_text_field( wp_unslash( $_GET['lbhotel_distance'] ) ) : '';
-$sort         = isset( $_GET['lbhotel_sort'] ) ? sanitize_key( wp_unslash( $_GET['lbhotel_sort'] ) ) : 'date';
-$paged        = max( 1, get_query_var( 'paged' ), get_query_var( 'page' ) );
+wp_enqueue_style( 'lbhotel-hotel', $theme_directory . '/hotel.css', array(), '1.0.0' );
+wp_enqueue_script( 'lbhotel-hotel', $theme_directory . '/hotel.js', array(), '1.0.0', true );
 
-$allowed_distances = array( '10', '20', '50' );
-if ( ! in_array( $distance, $allowed_distances, true ) ) {
-    $distance = '';
-}
-
-$allowed_sorts = array( 'date', 'price', 'rating' );
-if ( ! in_array( $sort, $allowed_sorts, true ) ) {
-    $sort = 'date';
-}
-
-$query_args = array(
-    'post_type'      => 'lbhotel_hotel',
-    'post_status'    => 'publish',
-    'paged'          => $paged,
-    'posts_per_page' => 9,
+wp_localize_script(
+    'lbhotel-hotel',
+    'lbHotelArchiveData',
+    array(
+        'context' => 'archive',
+    )
 );
 
-if ( $search_term ) {
-    $title_matches = get_posts(
-        array(
-            'post_type'      => 'lbhotel_hotel',
-            'post_status'    => 'publish',
-            's'              => $search_term,
-            'posts_per_page' => -1,
-            'fields'         => 'ids',
-        )
-    );
-
-    $city_matches = get_posts(
-        array(
-            'post_type'      => 'lbhotel_hotel',
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-            'fields'         => 'ids',
-            'meta_query'     => array(
-                array(
-                    'key'     => 'lbhotel_city',
-                    'value'   => $search_term,
-                    'compare' => 'LIKE',
-                ),
-            ),
-        )
-    );
-
-    $matched_ids = array_unique( array_merge( $title_matches, $city_matches ) );
-
-    $query_args['post__in'] = $matched_ids ? $matched_ids : array( 0 );
-}
-
-$meta_query = array();
-
-if ( $distance ) {
-    $distance_value = absint( $distance );
-    $meta_query[]   = array(
-        'relation' => 'OR',
-        array(
-            'key'     => 'lbhotel_distance_km',
-            'value'   => $distance_value,
-            'type'    => 'NUMERIC',
-            'compare' => '<=',
-        ),
-        array(
-            'key'     => 'lbhotel_distance_km',
-            'compare' => 'NOT EXISTS',
-        ),
-    );
-}
-
-if ( $meta_query ) {
-    if ( count( $meta_query ) > 1 ) {
-        $meta_query = array_merge( array( 'relation' => 'AND' ), $meta_query );
-    }
-
-    $query_args['meta_query'] = $meta_query;
-}
-
-switch ( $sort ) {
-    case 'price':
-        $query_args['meta_key'] = 'lbhotel_avg_price_per_night';
-        $query_args['orderby']  = 'meta_value_num';
-        $query_args['order']    = 'ASC';
-        break;
-    case 'rating':
-        $query_args['meta_key'] = 'lbhotel_star_rating';
-        $query_args['orderby']  = 'meta_value_num';
-        $query_args['order']    = 'DESC';
-        break;
-    default:
-        $query_args['orderby'] = 'date';
-        $query_args['order']   = 'DESC';
-        break;
-}
-
-$hotels_query = new WP_Query( $query_args );
+get_header();
 ?>
 
-<div class="hotel-container hotel-archive">
-    <header class="hotel-archive-header">
-        <h1 class="archive-title"><?php post_type_archive_title(); ?></h1>
-        <form class="hotel-archive-filters" method="get" action="<?php echo esc_url( get_post_type_archive_link( 'lbhotel_hotel' ) ); ?>">
-            <div class="filter-group">
-                <label for="lbhotel_search" class="screen-reader-text"><?php esc_html_e( 'Search hotels', 'lbhotel' ); ?></label>
-                <input type="search" id="lbhotel_search" name="lbhotel_search" placeholder="<?php esc_attr_e( 'Search by hotel or city', 'lbhotel' ); ?>" value="<?php echo esc_attr( $search_term ); ?>" />
-            </div>
-            <div class="filter-group">
-                <label for="lbhotel_distance" class="screen-reader-text"><?php esc_html_e( 'Filter by distance', 'lbhotel' ); ?></label>
-                <select id="lbhotel_distance" name="lbhotel_distance">
-                    <option value=""><?php esc_html_e( 'Any distance', 'lbhotel' ); ?></option>
-                    <?php foreach ( $allowed_distances as $option ) : ?>
-                        <option value="<?php echo esc_attr( $option ); ?>" <?php selected( $distance, $option ); ?>><?php echo esc_html( sprintf( _x( '%skm', 'distance filter label', 'lbhotel' ), $option ) ); ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <div class="filter-group">
-                <label for="lbhotel_sort" class="screen-reader-text"><?php esc_html_e( 'Sort hotels', 'lbhotel' ); ?></label>
-                <select id="lbhotel_sort" name="lbhotel_sort">
-                    <option value="date" <?php selected( $sort, 'date' ); ?>><?php esc_html_e( 'Newest', 'lbhotel' ); ?></option>
-                    <option value="price" <?php selected( $sort, 'price' ); ?>><?php esc_html_e( 'Price (Low to High)', 'lbhotel' ); ?></option>
-                    <option value="rating" <?php selected( $sort, 'rating' ); ?>><?php esc_html_e( 'Rating (High to Low)', 'lbhotel' ); ?></option>
-                </select>
-            </div>
-            <button type="submit" class="filter-submit"><?php esc_html_e( 'Apply', 'lbhotel' ); ?></button>
-        </form>
-    </header>
+<div id="content" class="site-content">
+    <div class="ast-container">
+        <?php if ( function_exists( 'astra_primary_content_top' ) ) { astra_primary_content_top(); } ?>
+        <div id="primary" <?php if ( function_exists( 'astra_primary_class' ) ) { astra_primary_class(); } else { echo 'class="content-area"'; } ?>>
+            <main id="main" class="site-main">
+                <?php if ( function_exists( 'astra_primary_content_before' ) ) { astra_primary_content_before(); } ?>
+                <div class="entry-content moroccan-entry" data-lbhotel-context="archive">
+                    <header class="moroccan-section moroccan-archive__header">
+                        <h1 class="moroccan-section__title"><?php post_type_archive_title(); ?></h1>
+                        <form id="lbhotel-filter-form" class="moroccan-filter-bar" aria-label="<?php esc_attr_e( 'Filter hotels', 'lbhotel' ); ?>" data-empty-message="<?php esc_attr_e( 'No hotels match your filters. Try a different search.', 'lbhotel' ); ?>">
+                            <label class="moroccan-filter-bar__group">
+                                <span class="screen-reader-text"><?php esc_html_e( 'Search hotels by title or city', 'lbhotel' ); ?></span>
+                                <input type="search" id="lbhotel-search" name="lbhotel_search" placeholder="<?php esc_attr_e( 'Search by hotel or city', 'lbhotel' ); ?>" />
+                            </label>
+                            <label class="moroccan-filter-bar__group">
+                                <span class="screen-reader-text"><?php esc_html_e( 'Filter hotels by distance', 'lbhotel' ); ?></span>
+                                <select id="lbhotel-distance" name="lbhotel_distance">
+                                    <option value="all"><?php esc_html_e( 'Any distance', 'lbhotel' ); ?></option>
+                                    <option value="10"><?php esc_html_e( 'Within 10 km', 'lbhotel' ); ?></option>
+                                    <option value="25"><?php esc_html_e( 'Within 25 km', 'lbhotel' ); ?></option>
+                                    <option value="50"><?php esc_html_e( 'Within 50 km', 'lbhotel' ); ?></option>
+                                </select>
+                            </label>
+                            <label class="moroccan-filter-bar__group">
+                                <span class="screen-reader-text"><?php esc_html_e( 'Sort hotels', 'lbhotel' ); ?></span>
+                                <select id="lbhotel-sort" name="lbhotel_sort">
+                                    <option value="date" selected><?php esc_html_e( 'Newest', 'lbhotel' ); ?></option>
+                                    <option value="price"><?php esc_html_e( 'Price (Low to High)', 'lbhotel' ); ?></option>
+                                    <option value="rating"><?php esc_html_e( 'Rating (High to Low)', 'lbhotel' ); ?></option>
+                                </select>
+                            </label>
+                            <button type="reset" class="moroccan-button moroccan-button--ghost"><?php esc_html_e( 'Clear', 'lbhotel' ); ?></button>
+                        </form>
+                    </header>
 
-    <?php if ( $hotels_query->have_posts() ) : ?>
-        <div class="hotel-archive-grid">
-            <?php
-            while ( $hotels_query->have_posts() ) :
-                $hotels_query->the_post();
+                    <?php if ( have_posts() ) : ?>
+                        <div class="moroccan-archive-grid" id="lbhotel-archive-grid">
+                            <?php while ( have_posts() ) : the_post(); ?>
+                                <?php
+                                $hotel_id      = get_the_ID();
+                                $star_rating   = (int) get_post_meta( $hotel_id, 'lbhotel_star_rating', true );
+                                $price_value   = get_post_meta( $hotel_id, 'lbhotel_avg_price_per_night', true );
+                                $city_value    = get_post_meta( $hotel_id, 'lbhotel_city', true );
+                                $distance_meta = get_post_meta( $hotel_id, 'lbhotel_distance_km', true );
+                                $gallery_meta  = get_post_meta( $hotel_id, 'lbhotel_gallery_images', true );
 
-                $hotel_id      = get_the_ID();
-                $stars         = (int) get_post_meta( $hotel_id, 'lbhotel_star_rating', true );
-                $city_value    = get_post_meta( $hotel_id, 'lbhotel_city', true );
-                $price_value   = get_post_meta( $hotel_id, 'lbhotel_avg_price_per_night', true );
-                $gallery_meta  = get_post_meta( $hotel_id, 'lbhotel_gallery_images', true );
-                $gallery_array = is_array( $gallery_meta ) ? $gallery_meta : array_filter( array_map( 'absint', (array) $gallery_meta ) );
+                                $gallery_ids = is_array( $gallery_meta ) ? $gallery_meta : array_filter( array_map( 'absint', (array) $gallery_meta ) );
 
-                $thumbnail_url = get_the_post_thumbnail_url( $hotel_id, 'large' );
-                if ( ! $thumbnail_url && ! empty( $gallery_array ) ) {
-                    $thumbnail_url = wp_get_attachment_image_url( (int) $gallery_array[0], 'large' );
-                }
+                                $thumbnail_url = get_the_post_thumbnail_url( $hotel_id, 'large' );
+                                if ( ! $thumbnail_url && $gallery_ids ) {
+                                    $thumbnail_url = wp_get_attachment_image_url( (int) $gallery_ids[0], 'large' );
+                                }
 
-                $card_style = $thumbnail_url ? sprintf( 'background-image: url(%s);', esc_url( $thumbnail_url ) ) : '';
+                                $price_numeric = '';
+                                $price_display = '';
+                                if ( '' !== $price_value && null !== $price_value ) {
+                                    if ( is_numeric( $price_value ) ) {
+                                        $price_numeric = (float) $price_value;
+                                        $price_display = number_format_i18n( (float) $price_value, 2 );
+                                    } else {
+                                        $price_display = sanitize_text_field( $price_value );
+                                    }
+                                }
 
-                $price_display = '';
-                if ( '' !== $price_value && null !== $price_value ) {
-                    $price_display = is_numeric( $price_value ) ? number_format_i18n( (float) $price_value, 2 ) : sanitize_text_field( $price_value );
-                }
-                ?>
-                <article id="post-<?php the_ID(); ?>" <?php post_class( 'hotel-card' ); ?>>
-                    <div class="hotel-card-image" style="<?php echo esc_attr( $card_style ); ?>">
-                        <?php if ( ! $thumbnail_url ) : ?>
-                            <span class="hotel-card-placeholder"><?php esc_html_e( 'No image available', 'lbhotel' ); ?></span>
-                        <?php endif; ?>
-                    </div>
-                    <div class="hotel-card-body">
-                        <h2 class="hotel-card-title"><?php the_title(); ?></h2>
-                        <?php if ( $stars > 0 ) : ?>
-                            <div class="hotel-card-stars" aria-label="<?php echo esc_attr( sprintf( _n( '%d star', '%d stars', $stars, 'lbhotel' ), $stars ) ); ?>">
-                                <?php echo wp_kses_post( str_repeat( '<span class="star">&#9733;</span>', min( 5, $stars ) ) ); ?>
-                            </div>
-                        <?php endif; ?>
-                        <?php if ( $city_value ) : ?>
-                            <p class="hotel-card-city"><?php echo esc_html( $city_value ); ?></p>
-                        <?php endif; ?>
-                        <?php if ( $price_display ) : ?>
-                            <p class="hotel-card-price"><?php echo esc_html( sprintf( __( 'From %s / night', 'lbhotel' ), $price_display ) ); ?></p>
-                        <?php endif; ?>
-                        <a class="hotel-card-button" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View Hotel', 'lbhotel' ); ?></a>
-                    </div>
-                </article>
-            <?php endwhile; ?>
+                                $distance_value = is_numeric( $distance_meta ) ? (float) $distance_meta : '';
+                                $date_value     = get_post_time( 'U' );
+                                ?>
+                                <article id="post-<?php the_ID(); ?>" <?php post_class( 'moroccan-card moroccan-card--hotel' ); ?> data-title="<?php echo esc_attr( get_the_title() ); ?>" data-city="<?php echo esc_attr( $city_value ); ?>" data-price="<?php echo esc_attr( $price_numeric ); ?>" data-rating="<?php echo esc_attr( $star_rating ); ?>" data-distance="<?php echo esc_attr( $distance_value ); ?>" data-date="<?php echo esc_attr( $date_value ); ?>">
+                                    <div class="moroccan-card__image">
+                                        <?php if ( $thumbnail_url ) : ?>
+                                            <img src="<?php echo esc_url( $thumbnail_url ); ?>" alt="<?php the_title_attribute(); ?>" />
+                                        <?php else : ?>
+                                            <span class="moroccan-card__placeholder"><?php esc_html_e( 'No image available', 'lbhotel' ); ?></span>
+                                        <?php endif; ?>
+                                    </div>
+                                    <div class="moroccan-card__body">
+                                        <h2 class="moroccan-card__title"><?php the_title(); ?></h2>
+                                        <?php if ( $star_rating > 0 ) : ?>
+                                            <div class="moroccan-stars" aria-label="<?php echo esc_attr( sprintf( _n( '%d star', '%d stars', $star_rating, 'lbhotel' ), $star_rating ) ); ?>">
+                                                <?php echo wp_kses_post( str_repeat( '<span aria-hidden="true">★</span>', min( 5, $star_rating ) ) ); ?>
+                                            </div>
+                                        <?php endif; ?>
+                                        <?php if ( $city_value ) : ?>
+                                            <p class="moroccan-card__meta">
+                                                <span class="moroccan-card__label"><?php esc_html_e( 'City:', 'lbhotel' ); ?></span>
+                                                <span class="moroccan-card__value"><?php echo esc_html( $city_value ); ?></span>
+                                            </p>
+                                        <?php endif; ?>
+                                        <?php if ( $price_display ) : ?>
+                                            <p class="moroccan-card__meta">
+                                                <span class="moroccan-card__label"><?php esc_html_e( 'From', 'lbhotel' ); ?></span>
+                                                <span class="moroccan-card__value moroccan-card__value--price"><?php echo esc_html( sprintf( __( '%s / night', 'lbhotel' ), $price_display ) ); ?></span>
+                                            </p>
+                                        <?php endif; ?>
+                                        <a class="moroccan-button" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View Hotel', 'lbhotel' ); ?></a>
+                                    </div>
+                                </article>
+                            <?php endwhile; ?>
+                        </div>
+
+                        <nav class="moroccan-pagination" aria-label="<?php esc_attr_e( 'Hotel pagination', 'lbhotel' ); ?>">
+                            <?php
+                            echo wp_kses_post(
+                                paginate_links(
+                                    array(
+                                        'prev_text' => '&laquo;',
+                                        'next_text' => '&raquo;',
+                                    )
+                                )
+                            );
+                            ?>
+                        </nav>
+                    <?php else : ?>
+                        <p class="moroccan-placeholder"><?php esc_html_e( 'No hotels found. Please adjust your filters.', 'lbhotel' ); ?></p>
+                    <?php endif; ?>
+                </div>
+                <?php if ( function_exists( 'astra_primary_content_after' ) ) { astra_primary_content_after(); } ?>
+            </main>
         </div>
-
-        <nav class="hotel-pagination" aria-label="<?php esc_attr_e( 'Hotel pagination', 'lbhotel' ); ?>">
-            <?php
-            echo wp_kses_post(
-                paginate_links(
-                    array(
-                        'total'   => $hotels_query->max_num_pages,
-                        'current' => $paged,
-                        'prev_text' => '&laquo;',
-                        'next_text' => '&raquo;',
-                    )
-                )
-            );
-            ?>
-        </nav>
-    <?php else : ?>
-        <p class="hotel-no-results"><?php esc_html_e( 'No hotels found matching your filters.', 'lbhotel' ); ?></p>
-    <?php endif; ?>
+        <?php if ( function_exists( 'astra_primary_content_bottom' ) ) { astra_primary_content_bottom(); } ?>
+    </div>
 </div>
 
-<?php
-wp_reset_postdata();
-get_footer();
+<?php get_footer(); ?>

--- a/hotel.css
+++ b/hotel.css
@@ -1,0 +1,372 @@
+/*
+ * Moroccan inspired styles for Le Bon Hotel templates.
+ */
+
+:root {
+    --lbhotel-red: #c1272d;
+    --lbhotel-green: #006233;
+    --lbhotel-sand: #f8f3ea;
+    --lbhotel-night: #1a1a1a;
+    --lbhotel-text: #333333;
+}
+
+body.lbhotel-theme-active,
+.entry-content.moroccan-entry {
+    background-color: var(--lbhotel-sand);
+    background-image: radial-gradient(circle at 1px 1px, rgba(0, 0, 0, 0.05) 1px, transparent 0),
+        radial-gradient(circle at 25px 25px, rgba(0, 0, 0, 0.04) 1px, transparent 0);
+    background-size: 32px 32px;
+    color: var(--lbhotel-text);
+    padding: 2rem;
+}
+
+.moroccan-section {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 20px;
+    border: 2px solid rgba(193, 39, 45, 0.12);
+    box-shadow: 0 15px 35px rgba(0, 0, 0, 0.08);
+    margin-bottom: 2.5rem;
+    padding: 2rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.moroccan-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(135deg, rgba(193, 39, 45, 0.08) 25%, transparent 25%),
+        linear-gradient(225deg, rgba(0, 98, 51, 0.08) 25%, transparent 25%),
+        linear-gradient(45deg, rgba(193, 39, 45, 0.08) 25%, transparent 25%),
+        linear-gradient(315deg, rgba(0, 98, 51, 0.08) 25%, rgba(193, 39, 45, 0.08) 25%);
+    background-size: 20px 20px;
+    opacity: 0.4;
+    z-index: 0;
+}
+
+.moroccan-section > * {
+    position: relative;
+    z-index: 1;
+}
+
+.moroccan-section__title {
+    font-family: "Playfair Display", "Times New Roman", serif;
+    font-size: clamp(1.5rem, 2.2vw, 2rem);
+    color: var(--lbhotel-green);
+    margin-bottom: 1.5rem;
+}
+
+.moroccan-hero__title {
+    font-size: clamp(2rem, 3vw, 2.75rem);
+    margin-bottom: 0.5rem;
+}
+
+.moroccan-hero__location {
+    font-size: 1.1rem;
+    color: rgba(26, 26, 26, 0.75);
+}
+
+.moroccan-hero__details {
+    display: grid;
+    gap: 1rem 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    margin-top: 2rem;
+}
+
+.moroccan-detail .label {
+    font-weight: 700;
+    color: var(--lbhotel-red);
+    margin-right: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.moroccan-stars {
+    display: inline-flex;
+    gap: 0.25rem;
+    font-size: 1.25rem;
+    color: #ffcc33;
+}
+
+.moroccan-gallery__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.moroccan-gallery__item {
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+    display: block;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.moroccan-gallery__item img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.moroccan-gallery__item:hover,
+.moroccan-gallery__item:focus {
+    transform: translateY(-6px) scale(1.02);
+    box-shadow: 0 20px 35px rgba(193, 39, 45, 0.25);
+}
+
+.moroccan-iframe-wrapper {
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.15);
+    aspect-ratio: 16 / 9;
+}
+
+.moroccan-iframe-wrapper iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.moroccan-map__canvas {
+    width: 100%;
+    height: 420px;
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.2);
+    border: 2px solid rgba(0, 98, 51, 0.15);
+}
+
+.lbhotel-marker span {
+    display: block;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--lbhotel-red), var(--lbhotel-green));
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.8), 0 10px 20px rgba(0, 0, 0, 0.3);
+}
+
+.lbhotel-marker.lbhotel-marker--current span {
+    width: 24px;
+    height: 24px;
+}
+
+.moroccan-placeholder {
+    font-style: italic;
+    color: rgba(26, 26, 26, 0.7);
+}
+
+.moroccan-button,
+.moroccan-button:visited,
+.moroccan-filter-bar__group select,
+.moroccan-filter-bar__group input[type="search"] {
+    border-radius: 999px;
+    border: none;
+    padding: 0.65rem 1.5rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.moroccan-button,
+.moroccan-button:visited {
+    background: linear-gradient(135deg, var(--lbhotel-red), var(--lbhotel-green));
+    color: #ffffff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    box-shadow: 0 12px 25px rgba(193, 39, 45, 0.35);
+}
+
+.moroccan-button:hover,
+.moroccan-button:focus {
+    transform: translateY(-3px);
+    box-shadow: 0 20px 35px rgba(0, 98, 51, 0.45);
+    color: #ffffff;
+}
+
+.moroccan-button--ghost {
+    background: transparent;
+    border: 2px solid var(--lbhotel-green);
+    color: var(--lbhotel-green);
+    box-shadow: none;
+}
+
+.moroccan-button--ghost:hover,
+.moroccan-button--ghost:focus {
+    background: rgba(0, 98, 51, 0.08);
+    color: var(--lbhotel-green);
+}
+
+.moroccan-filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+.moroccan-filter-bar__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.moroccan-filter-bar__group input[type="search"],
+.moroccan-filter-bar__group select {
+    min-width: 200px;
+    border: 2px solid rgba(193, 39, 45, 0.15);
+    background-color: rgba(255, 255, 255, 0.85);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.moroccan-archive-grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    margin-top: 2.5rem;
+}
+
+.moroccan-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 18px 35px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    display: flex;
+    flex-direction: column;
+}
+
+.moroccan-card:hover,
+.moroccan-card:focus-within {
+    transform: translateY(-8px);
+    box-shadow: 0 25px 45px rgba(0, 0, 0, 0.18);
+}
+
+.moroccan-card__image {
+    position: relative;
+    background: rgba(0, 0, 0, 0.05);
+    min-height: 190px;
+}
+
+.moroccan-card__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.moroccan-card__placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-style: italic;
+    color: rgba(26, 26, 26, 0.6);
+}
+
+.moroccan-card__body {
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    flex: 1;
+}
+
+.moroccan-card__title {
+    font-size: 1.35rem;
+    color: var(--lbhotel-night);
+    margin: 0;
+}
+
+.moroccan-card__meta {
+    margin: 0;
+    font-size: 0.95rem;
+    display: flex;
+    gap: 0.4rem;
+    align-items: baseline;
+}
+
+.moroccan-card__label {
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--lbhotel-green);
+    letter-spacing: 0.04em;
+}
+
+.moroccan-card__value--price {
+    color: var(--lbhotel-red);
+    font-weight: 700;
+}
+
+.moroccan-pagination {
+    margin-top: 3rem;
+    text-align: center;
+}
+
+.moroccan-pagination .page-numbers {
+    display: inline-block;
+    margin: 0 0.4rem;
+    padding: 0.6rem 1rem;
+    border-radius: 999px;
+    background: rgba(193, 39, 45, 0.12);
+    color: var(--lbhotel-night);
+    text-decoration: none;
+}
+
+.moroccan-pagination .page-numbers.current,
+.moroccan-pagination .page-numbers:hover {
+    background: linear-gradient(135deg, var(--lbhotel-red), var(--lbhotel-green));
+    color: #ffffff;
+    box-shadow: 0 12px 25px rgba(0, 0, 0, 0.15);
+}
+
+.lbhotel-lightbox {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    padding: 2rem;
+}
+
+.lbhotel-lightbox__image {
+    max-width: min(900px, 90vw);
+    max-height: 85vh;
+    border-radius: 12px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+}
+
+.lbhotel-lightbox__close {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    background: linear-gradient(135deg, var(--lbhotel-green), var(--lbhotel-red));
+    color: #ffffff;
+    border: none;
+    border-radius: 50%;
+    width: 44px;
+    height: 44px;
+    font-size: 1.25rem;
+    cursor: pointer;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+}
+
+@media (max-width: 768px) {
+    .entry-content.moroccan-entry {
+        padding: 1.25rem;
+    }
+
+    .moroccan-section {
+        padding: 1.5rem;
+    }
+
+    .moroccan-filter-bar__group input[type="search"],
+    .moroccan-filter-bar__group select {
+        min-width: 160px;
+    }
+}

--- a/hotel.js
+++ b/hotel.js
@@ -1,0 +1,333 @@
+(function () {
+    'use strict';
+
+    function activateTheme() {
+        if (document.body && !document.body.classList.contains('lbhotel-theme-active')) {
+            document.body.classList.add('lbhotel-theme-active');
+        }
+    }
+
+    function initialiseMap() {
+        if (typeof window === 'undefined' || typeof L === 'undefined') {
+            return;
+        }
+
+        var mapData = window.lbHotelMapData;
+        var mapContainer = document.getElementById('lbhotel-map');
+
+        if (!mapContainer || !mapData) {
+            return;
+        }
+
+        var dummyCoordinates = [
+            { lat: 31.6295, lng: -7.9811 }, // Marrakech
+            { lat: 33.5731, lng: -7.5898 }, // Casablanca
+            { lat: 34.0209, lng: -6.8416 }, // Rabat
+            { lat: 35.7595, lng: -5.8340 }, // Tangier
+            { lat: 30.4278, lng: -9.5981 }  // Agadir
+        ];
+
+        var hotels = Array.isArray(mapData.hotels) ? mapData.hotels.slice() : [];
+        if (!hotels.length) {
+            hotels = dummyCoordinates.map(function (coord, index) {
+                return {
+                    id: 'dummy-' + index,
+                    title: 'Le Bon Hotel ' + (index + 1),
+                    stars: 4,
+                    lat: coord.lat,
+                    lng: coord.lng
+                };
+            });
+        }
+
+        hotels.forEach(function (hotel, index) {
+            if (typeof hotel.lat !== 'number' || typeof hotel.lng !== 'number') {
+                var fallback = dummyCoordinates[index % dummyCoordinates.length];
+                hotel.lat = fallback.lat;
+                hotel.lng = fallback.lng;
+            }
+        });
+
+        var focusLat = mapData.defaultCenter && mapData.defaultCenter.lat ? mapData.defaultCenter.lat : 31.7917;
+        var focusLng = mapData.defaultCenter && mapData.defaultCenter.lng ? mapData.defaultCenter.lng : -7.0926;
+        var focusZoom = 6;
+
+        if (mapData.currentHotel && typeof mapData.currentHotel.lat === 'number' && typeof mapData.currentHotel.lng === 'number') {
+            focusLat = mapData.currentHotel.lat;
+            focusLng = mapData.currentHotel.lng;
+            focusZoom = 13;
+        }
+
+        var map = L.map(mapContainer).setView([focusLat, focusLng], focusZoom);
+
+        var streetLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        var satelliteLayer = null;
+        if (L.esri && typeof L.esri.basemapLayer === 'function') {
+            satelliteLayer = L.esri.basemapLayer('Imagery');
+        }
+
+        var baseLayers = {
+            Street: streetLayer
+        };
+
+        if (satelliteLayer) {
+            baseLayers.Satellite = satelliteLayer;
+        }
+
+        L.control.layers(baseLayers, null, { position: 'topright' }).addTo(map);
+
+        var bounds = [];
+        var currentId = mapData.currentHotel ? mapData.currentHotel.id : null;
+
+        hotels.forEach(function (hotel) {
+            if (typeof hotel.lat !== 'number' || typeof hotel.lng !== 'number') {
+                return;
+            }
+
+            var markerOptions = {
+                icon: L.divIcon({
+                    className: 'lbhotel-marker',
+                    html: '<span></span>',
+                    iconSize: [18, 18]
+                })
+            };
+
+            if (hotel.id === currentId) {
+                markerOptions.icon = L.divIcon({
+                    className: 'lbhotel-marker lbhotel-marker--current',
+                    html: '<span></span>',
+                    iconSize: [24, 24]
+                });
+            }
+
+            var marker = L.marker([hotel.lat, hotel.lng], markerOptions).addTo(map);
+            var starDisplay = '';
+            if (hotel.stars) {
+                var cappedStars = Math.max(0, Math.min(5, parseInt(hotel.stars, 10)));
+                starDisplay = '<div class="moroccan-stars">' + '★'.repeat(cappedStars) + '</div>';
+            }
+            var title = hotel.title ? hotel.title : 'Le Bon Hotel';
+            marker.bindPopup('<strong>' + title + '</strong><br />' + starDisplay);
+
+            if (hotel.id === currentId) {
+                marker.openPopup();
+            }
+
+            bounds.push([hotel.lat, hotel.lng]);
+        });
+
+        if (bounds.length > 1) {
+            map.fitBounds(bounds, { padding: [40, 40] });
+        }
+
+        setTimeout(function () {
+            map.invalidateSize();
+        }, 100);
+    }
+
+    function initialiseLightbox() {
+        var gallery = document.querySelector('[data-lightbox-gallery]');
+        if (!gallery) {
+            return;
+        }
+
+        gallery.addEventListener('click', function (event) {
+            var trigger = event.target.closest('[data-lightbox-item]');
+            if (!trigger) {
+                return;
+            }
+            event.preventDefault();
+            openLightbox(trigger.getAttribute('href'));
+        });
+    }
+
+    function openLightbox(imageUrl) {
+        if (!imageUrl) {
+            return;
+        }
+
+        var lightbox = document.createElement('div');
+        lightbox.className = 'lbhotel-lightbox';
+
+        var closeButton = document.createElement('button');
+        closeButton.type = 'button';
+        closeButton.className = 'lbhotel-lightbox__close';
+        closeButton.innerHTML = '&times;';
+
+        var image = document.createElement('img');
+        image.className = 'lbhotel-lightbox__image';
+        image.src = imageUrl;
+        image.alt = '';
+
+        lightbox.appendChild(closeButton);
+        lightbox.appendChild(image);
+        document.body.appendChild(lightbox);
+
+        function removeLightbox() {
+            if (lightbox && lightbox.parentNode) {
+                lightbox.parentNode.removeChild(lightbox);
+            }
+            document.removeEventListener('keydown', escListener);
+        }
+
+        lightbox.addEventListener('click', function (event) {
+            if (event.target === lightbox) {
+                removeLightbox();
+            }
+        });
+
+        closeButton.addEventListener('click', removeLightbox);
+        function escListener(event) {
+            if (event.key === 'Escape') {
+                removeLightbox();
+            }
+        }
+
+        document.addEventListener('keydown', escListener);
+    }
+
+    function initialiseArchiveFilters() {
+        var filterForm = document.getElementById('lbhotel-filter-form');
+        var grid = document.getElementById('lbhotel-archive-grid');
+
+        if (!filterForm || !grid) {
+            return;
+        }
+
+        var cards = Array.prototype.slice.call(grid.querySelectorAll('.moroccan-card--hotel'));
+        var searchInput = document.getElementById('lbhotel-search');
+        var distanceSelect = document.getElementById('lbhotel-distance');
+        var sortSelect = document.getElementById('lbhotel-sort');
+        var pagination = document.querySelector('.moroccan-pagination');
+
+        var emptyMessage = document.createElement('p');
+        emptyMessage.className = 'moroccan-placeholder';
+        emptyMessage.textContent = filterForm.getAttribute('data-empty-message') || 'No hotels match your filters.';
+        emptyMessage.style.display = 'none';
+        grid.parentNode.insertBefore(emptyMessage, grid.nextSibling);
+
+        function matchSearch(card, searchTerm) {
+            if (!searchTerm) {
+                return true;
+            }
+            var title = (card.getAttribute('data-title') || '').toLowerCase();
+            var city = (card.getAttribute('data-city') || '').toLowerCase();
+            return title.indexOf(searchTerm) !== -1 || city.indexOf(searchTerm) !== -1;
+        }
+
+        function matchDistance(card, distanceValue) {
+            if (!distanceValue || distanceValue === 'all') {
+                return true;
+            }
+            var cardDistance = parseFloat(card.getAttribute('data-distance'));
+            if (isNaN(cardDistance)) {
+                return true;
+            }
+            return cardDistance <= parseFloat(distanceValue);
+        }
+
+        function applyFilters() {
+            var searchTerm = searchInput ? searchInput.value.trim().toLowerCase() : '';
+            var distanceValue = distanceSelect ? distanceSelect.value : 'all';
+            var visibleCount = 0;
+
+            cards.forEach(function (card) {
+                var visible = matchSearch(card, searchTerm) && matchDistance(card, distanceValue);
+                card.dataset.visible = visible ? 'true' : 'false';
+                card.style.display = visible ? '' : 'none';
+                if (visible) {
+                    visibleCount++;
+                }
+            });
+
+            emptyMessage.style.display = visibleCount ? 'none' : 'block';
+            if (pagination) {
+                pagination.style.display = visibleCount ? '' : 'none';
+            }
+        }
+
+        function sortCards() {
+            if (!sortSelect) {
+                return;
+            }
+            var sortValue = sortSelect.value;
+            var cardsToSort = cards.slice();
+
+            cardsToSort.sort(function (a, b) {
+                var visibleA = a.dataset.visible !== 'false';
+                var visibleB = b.dataset.visible !== 'false';
+
+                if (!visibleA && visibleB) {
+                    return 1;
+                }
+                if (visibleA && !visibleB) {
+                    return -1;
+                }
+
+                if (sortValue === 'price') {
+                    var priceA = parseFloat(a.getAttribute('data-price'));
+                    var priceB = parseFloat(b.getAttribute('data-price'));
+                    if (isNaN(priceA)) { priceA = Number.MAX_SAFE_INTEGER; }
+                    if (isNaN(priceB)) { priceB = Number.MAX_SAFE_INTEGER; }
+                    return priceA - priceB;
+                }
+
+                if (sortValue === 'rating') {
+                    var ratingA = parseInt(a.getAttribute('data-rating'), 10) || 0;
+                    var ratingB = parseInt(b.getAttribute('data-rating'), 10) || 0;
+                    return ratingB - ratingA;
+                }
+
+                var dateA = parseInt(a.getAttribute('data-date'), 10) || 0;
+                var dateB = parseInt(b.getAttribute('data-date'), 10) || 0;
+                return dateB - dateA;
+            });
+
+            cardsToSort.forEach(function (card) {
+                grid.appendChild(card);
+            });
+        }
+
+        function updateView() {
+            applyFilters();
+            sortCards();
+        }
+
+        if (searchInput) {
+            searchInput.addEventListener('input', updateView);
+        }
+        if (distanceSelect) {
+            distanceSelect.addEventListener('change', updateView);
+        }
+        if (sortSelect) {
+            sortSelect.addEventListener('change', updateView);
+        }
+
+        filterForm.addEventListener('reset', function () {
+            setTimeout(function () {
+                if (searchInput) {
+                    searchInput.value = '';
+                }
+                if (distanceSelect) {
+                    distanceSelect.value = 'all';
+                }
+                if (sortSelect) {
+                    sortSelect.value = 'date';
+                }
+                updateView();
+            }, 0);
+        });
+
+        updateView();
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        activateTheme();
+        initialiseMap();
+        initialiseLightbox();
+        initialiseArchiveFilters();
+    });
+})();

--- a/single-lbhotel_hotel.php
+++ b/single-lbhotel_hotel.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Template for displaying a single Le Bon Hotel entry.
+ * Astra override template for displaying a single Le Bon Hotel entry.
  *
- * Copy this file into your active theme to override the single view for the
- * `lbhotel_hotel` custom post type provided by the Le Bon Hotel plugin.
+ * Copy this file into your active theme (or child theme) to override the
+ * single view for the `lbhotel_hotel` custom post type provided by the
+ * Le Bon Hotel plugin.
  *
  * @package LeBonHotel
  */
@@ -12,227 +13,182 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+$theme_directory = get_stylesheet_directory_uri();
+
 wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', array(), '1.9.4' );
+wp_enqueue_style( 'lbhotel-hotel', $theme_directory . '/hotel.css', array( 'leaflet' ), '1.0.0' );
+
 wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), '1.9.4', true );
 wp_enqueue_script( 'esri-leaflet', 'https://unpkg.com/esri-leaflet@3.0.11/dist/esri-leaflet.js', array( 'leaflet' ), '3.0.11', true );
+wp_enqueue_script( 'lbhotel-hotel', $theme_directory . '/hotel.js', array( 'leaflet', 'esri-leaflet' ), '1.0.0', true );
+
+$current_id    = get_queried_object_id();
+$current_lat   = $current_id ? get_post_meta( $current_id, 'lbhotel_latitude', true ) : null;
+$current_lng   = $current_id ? get_post_meta( $current_id, 'lbhotel_longitude', true ) : null;
+$hotels_query  = get_posts(
+    array(
+        'post_type'      => 'lbhotel_hotel',
+        'post_status'    => 'publish',
+        'posts_per_page' => -1,
+        'fields'         => 'ids',
+    )
+);
+
+$hotels_payload = array();
+
+foreach ( $hotels_query as $hotel_id ) {
+    $lat = get_post_meta( $hotel_id, 'lbhotel_latitude', true );
+    $lng = get_post_meta( $hotel_id, 'lbhotel_longitude', true );
+
+    $hotels_payload[] = array(
+        'id'    => $hotel_id,
+        'title' => get_the_title( $hotel_id ),
+        'url'   => get_permalink( $hotel_id ),
+        'stars' => (int) get_post_meta( $hotel_id, 'lbhotel_star_rating', true ),
+        'lat'   => is_numeric( $lat ) ? (float) $lat : null,
+        'lng'   => is_numeric( $lng ) ? (float) $lng : null,
+    );
+}
+
+$current_payload = array(
+    'id'    => $current_id,
+    'title' => $current_id ? get_the_title( $current_id ) : '',
+    'lat'   => is_numeric( $current_lat ) ? (float) $current_lat : null,
+    'lng'   => is_numeric( $current_lng ) ? (float) $current_lng : null,
+);
+
+wp_localize_script(
+    'lbhotel-hotel',
+    'lbHotelMapData',
+    array(
+        'context'       => 'single',
+        'defaultCenter' => array(
+            'lat' => 31.7917,
+            'lng' => -7.0926,
+        ),
+        'currentHotel'  => $current_payload,
+        'hotels'        => $hotels_payload,
+    )
+);
 
 get_header();
 ?>
 
-<div class="hotel-container">
-    <?php
-    while ( have_posts() ) :
-        the_post();
-
-        $hotel_id   = get_the_ID();
-        $city       = get_post_meta( $hotel_id, 'lbhotel_city', true );
-        $region     = get_post_meta( $hotel_id, 'lbhotel_region', true );
-        $postal     = get_post_meta( $hotel_id, 'lbhotel_postal_code', true );
-        $country    = get_post_meta( $hotel_id, 'lbhotel_country', true );
-        $star_rating = (int) get_post_meta( $hotel_id, 'lbhotel_star_rating', true );
-        $rooms_total = get_post_meta( $hotel_id, 'lbhotel_rooms_total', true );
-        $checkin     = get_post_meta( $hotel_id, 'lbhotel_checkin_time', true );
-        $checkout    = get_post_meta( $hotel_id, 'lbhotel_checkout_time', true );
-        $avg_price   = get_post_meta( $hotel_id, 'lbhotel_avg_price_per_night', true );
-        $gallery_ids = get_post_meta( $hotel_id, 'lbhotel_gallery_images', true );
-        $virtual_tour = get_post_meta( $hotel_id, 'lbhotel_virtual_tour_url', true );
-        $booking_url = get_post_meta( $hotel_id, 'lbhotel_booking_url', true );
-        $latitude    = get_post_meta( $hotel_id, 'lbhotel_latitude', true );
-        $longitude   = get_post_meta( $hotel_id, 'lbhotel_longitude', true );
-
-        if ( ! is_array( $gallery_ids ) ) {
-            $gallery_ids = array_filter( array_map( 'absint', (array) $gallery_ids ) );
-        }
-
-        $star_rating        = max( 0, min( 5, $star_rating ) );
-        $formatted_price    = ( '' !== $avg_price && null !== $avg_price ) ? ( is_numeric( $avg_price ) ? number_format_i18n( (float) $avg_price, 2 ) : sanitize_text_field( $avg_price ) ) : '';
-        $location_parts     = array_filter( array( $city, $region, $postal, $country ) );
-        $current_has_coords = is_numeric( $latitude ) && is_numeric( $longitude );
-
-        $all_hotels = get_posts(
-            array(
-                'post_type'      => 'lbhotel_hotel',
-                'posts_per_page' => -1,
-                'post_status'    => 'publish',
-                'fields'         => 'ids',
-            )
-        );
-
-        $hotels_data = array();
-
-        foreach ( $all_hotels as $hotel_post_id ) {
-            $lat = get_post_meta( $hotel_post_id, 'lbhotel_latitude', true );
-            $lng = get_post_meta( $hotel_post_id, 'lbhotel_longitude', true );
-
-            if ( ! is_numeric( $lat ) || ! is_numeric( $lng ) ) {
-                continue;
-            }
-
-            $hotels_data[] = array(
-                'id'    => $hotel_post_id,
-                'title' => esc_html( get_the_title( $hotel_post_id ) ),
-                'lat'   => (float) $lat,
-                'lng'   => (float) $lng,
-                'stars' => (int) get_post_meta( $hotel_post_id, 'lbhotel_star_rating', true ),
-            );
-        }
-
-        $map_payload = array(
-            'defaultCenter' => array(
-                'lat' => 31.7917,
-                'lng' => -7.0926,
-            ),
-            'currentHotel'  => array(
-                'id'    => $hotel_id,
-                'lat'   => $current_has_coords ? (float) $latitude : null,
-                'lng'   => $current_has_coords ? (float) $longitude : null,
-            ),
-            'hotels'        => $hotels_data,
-        );
-
-        $map_script = 'document.addEventListener("DOMContentLoaded", function() {
-            if ( typeof L === "undefined" ) {
-                return;
-            }
-            var data = ' . wp_json_encode( $map_payload, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) . ';
-            var mapEl = document.getElementById("hotel-map");
-            if ( ! mapEl ) {
-                return;
-            }
-            var center = [data.defaultCenter.lat, data.defaultCenter.lng];
-            var zoom = 6;
-            if ( data.currentHotel && data.currentHotel.lat && data.currentHotel.lng ) {
-                center = [data.currentHotel.lat, data.currentHotel.lng];
-                zoom = 13;
-            } else if ( data.hotels.length ) {
-                var first = data.hotels[0];
-                center = [first.lat, first.lng];
-            }
-            var map = L.map("hotel-map").setView(center, zoom);
-            var osmLayer = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-                attribution: "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors"
-            });
-            osmLayer.addTo(map);
-            var baseLayers = {
-                "OpenStreetMap": osmLayer
-            };
-            if ( L.esri && L.esri.basemapLayer ) {
-                baseLayers["Satellite"] = L.esri.basemapLayer("Imagery");
-            }
-            L.control.layers(baseLayers, null, { position: "topright" }).addTo(map);
-            data.hotels.forEach(function(hotel) {
-                if ( !hotel.lat || !hotel.lng ) {
-                    return;
-                }
-                var marker = L.marker([hotel.lat, hotel.lng]).addTo(map);
-                var stars = "";
-                if ( hotel.stars ) {
-                    stars = "<span class=\"hotel-map-stars\">" + "★".repeat(Math.max(0, Math.min(5, hotel.stars))) + "</span>";
-                }
-                marker.bindPopup("<strong>" + hotel.title + "</strong><br>" + stars);
-                if ( hotel.id === data.currentHotel.id ) {
-                    marker.openPopup();
-                }
-            });
-        });';
-
-        static $map_inline_added = false;
-
-        if ( ! $map_inline_added ) {
-            wp_add_inline_script( 'leaflet', $map_script );
-            $map_inline_added = true;
-        }
-        ?>
-
-        <article id="post-<?php the_ID(); ?>" <?php post_class( 'hotel-single' ); ?>>
-            <header class="hotel-hero">
-                <h1 class="hotel-title"><?php the_title(); ?></h1>
-                <?php if ( $star_rating > 0 ) : ?>
-                    <div class="hotel-star-rating" aria-label="<?php echo esc_attr( sprintf( _n( '%d star', '%d stars', $star_rating, 'lbhotel' ), $star_rating ) ); ?>">
-                        <?php echo wp_kses_post( str_repeat( '<span class="hotel-star">&#9733;</span>', $star_rating ) ); ?>
-                    </div>
-                <?php endif; ?>
-                <?php if ( $location_parts ) : ?>
-                    <p class="hotel-location"><?php echo esc_html( implode( ', ', $location_parts ) ); ?></p>
-                <?php endif; ?>
-            </header>
-
-            <section class="hotel-meta-grid">
-                <?php if ( $rooms_total ) : ?>
-                    <div class="hotel-meta-card">
-                        <span class="meta-label"><?php esc_html_e( 'Rooms Total', 'lbhotel' ); ?></span>
-                        <span class="meta-value"><?php echo esc_html( number_format_i18n( (int) $rooms_total ) ); ?></span>
-                    </div>
-                <?php endif; ?>
-                <?php if ( $checkin ) : ?>
-                    <div class="hotel-meta-card">
-                        <span class="meta-label"><?php esc_html_e( 'Check-in', 'lbhotel' ); ?></span>
-                        <span class="meta-value"><?php echo esc_html( $checkin ); ?></span>
-                    </div>
-                <?php endif; ?>
-                <?php if ( $checkout ) : ?>
-                    <div class="hotel-meta-card">
-                        <span class="meta-label"><?php esc_html_e( 'Check-out', 'lbhotel' ); ?></span>
-                        <span class="meta-value"><?php echo esc_html( $checkout ); ?></span>
-                    </div>
-                <?php endif; ?>
-                <?php if ( $formatted_price ) : ?>
-                    <div class="hotel-meta-card">
-                        <span class="meta-label"><?php esc_html_e( 'Avg. Price / Night', 'lbhotel' ); ?></span>
-                        <span class="meta-value"><?php echo esc_html( $formatted_price ); ?></span>
-                    </div>
-                <?php endif; ?>
-            </section>
-
-            <div class="hotel-content entry-content">
-                <?php the_content(); ?>
-            </div>
-
-            <?php if ( ! empty( $gallery_ids ) ) : ?>
-                <section class="hotel-gallery" aria-label="<?php esc_attr_e( 'Hotel gallery', 'lbhotel' ); ?>">
-                    <h2 class="section-title"><?php esc_html_e( 'Gallery', 'lbhotel' ); ?></h2>
-                    <div class="hotel-gallery-grid">
-                        <?php foreach ( $gallery_ids as $attachment_id ) :
-                            $image_html = wp_get_attachment_image( $attachment_id, 'large', false, array( 'class' => 'hotel-gallery-image' ) );
-                            if ( $image_html ) :
-                                ?>
-                                <figure class="hotel-gallery-item"><?php echo wp_kses_post( $image_html ); ?></figure>
+<div id="content" class="site-content">
+    <div class="ast-container">
+        <?php if ( function_exists( 'astra_primary_content_top' ) ) { astra_primary_content_top(); } ?>
+        <div id="primary" <?php if ( function_exists( 'astra_primary_class' ) ) { astra_primary_class(); } else { echo 'class="content-area"'; } ?>>
+            <main id="main" class="site-main">
+                <?php if ( function_exists( 'astra_primary_content_before' ) ) { astra_primary_content_before(); } ?>
+                <?php while ( have_posts() ) : the_post(); ?>
+                    <?php if ( function_exists( 'astra_entry_before' ) ) { astra_entry_before(); } ?>
+                    <article id="post-<?php the_ID(); ?>" <?php post_class( 'lbhotel-single moroccan-card' ); ?>>
+                        <?php if ( function_exists( 'astra_entry_top' ) ) { astra_entry_top(); } ?>
+                        <?php if ( function_exists( 'astra_entry_content_before' ) ) { astra_entry_content_before(); } ?>
+                        <div class="entry-content moroccan-entry" data-lbhotel-context="single">
                             <?php
-                            endif;
-                        endforeach;
-                        ?>
-                    </div>
-                </section>
-            <?php endif; ?>
+                            $hotel_id     = get_the_ID();
+                            $city         = get_post_meta( $hotel_id, 'lbhotel_city', true );
+                            $region       = get_post_meta( $hotel_id, 'lbhotel_region', true );
+                            $postal       = get_post_meta( $hotel_id, 'lbhotel_postal_code', true );
+                            $country      = get_post_meta( $hotel_id, 'lbhotel_country', true );
+                            $star_rating  = (int) get_post_meta( $hotel_id, 'lbhotel_star_rating', true );
+                            $rooms_total  = get_post_meta( $hotel_id, 'lbhotel_rooms_total', true );
+                            $checkin      = get_post_meta( $hotel_id, 'lbhotel_checkin_time', true );
+                            $checkout     = get_post_meta( $hotel_id, 'lbhotel_checkout_time', true );
+                            $avg_price    = get_post_meta( $hotel_id, 'lbhotel_avg_price_per_night', true );
+                            $gallery_meta = get_post_meta( $hotel_id, 'lbhotel_gallery_images', true );
+                            $tour_url     = get_post_meta( $hotel_id, 'lbhotel_virtual_tour_url', true );
+                            $booking_url  = get_post_meta( $hotel_id, 'lbhotel_booking_url', true );
 
-            <?php if ( $virtual_tour ) : ?>
-                <section class="hotel-virtual-tour">
-                    <h2 class="section-title"><?php esc_html_e( 'Virtual Tour', 'lbhotel' ); ?></h2>
-                    <div class="virtual-tour-frame">
-                        <iframe src="<?php echo esc_url( $virtual_tour ); ?>" loading="lazy" allowfullscreen title="<?php echo esc_attr( get_the_title() ); ?>"></iframe>
-                    </div>
-                </section>
-            <?php endif; ?>
+                            $gallery_ids = is_array( $gallery_meta ) ? $gallery_meta : array_filter( array_map( 'absint', (array) $gallery_meta ) );
 
-            <section class="hotel-map-section">
-                <h2 class="section-title"><?php esc_html_e( 'Explore on the Map', 'lbhotel' ); ?></h2>
-                <div id="hotel-map" class="hotel-map" role="application" aria-label="<?php esc_attr_e( 'Hotel locations map', 'lbhotel' ); ?>"></div>
-            </section>
+                            $price_display = '';
+                            if ( '' !== $avg_price && null !== $avg_price ) {
+                                $price_display = is_numeric( $avg_price ) ? number_format_i18n( (float) $avg_price, 2 ) : sanitize_text_field( $avg_price );
+                            }
 
-            <section class="hotel-booking">
-                <h2 class="section-title"><?php esc_html_e( 'Reservations', 'lbhotel' ); ?></h2>
-                <div class="booking-frame">
-                    <?php if ( $booking_url ) : ?>
-                        <iframe src="<?php echo esc_url( $booking_url ); ?>" loading="lazy" title="<?php esc_attr_e( 'Hotel booking form', 'lbhotel' ); ?>"></iframe>
-                    <?php else : ?>
-                        <div class="booking-placeholder"><?php esc_html_e( 'Reservation coming soon', 'lbhotel' ); ?></div>
-                    <?php endif; ?>
-                </div>
-            </section>
-        </article>
+                            $location_bits = array_filter( array( $city, $region, $postal, $country ) );
+                            ?>
 
-    <?php endwhile; ?>
+                            <section class="moroccan-section moroccan-hero">
+                                <header class="moroccan-hero__header">
+                                    <h1 class="moroccan-hero__title"><?php the_title(); ?></h1>
+                                    <?php if ( $star_rating > 0 ) : ?>
+                                        <div class="moroccan-stars" aria-label="<?php echo esc_attr( sprintf( _n( '%d star', '%d stars', $star_rating, 'lbhotel' ), $star_rating ) ); ?>">
+                                            <?php echo wp_kses_post( str_repeat( '<span aria-hidden="true">★</span>', min( 5, $star_rating ) ) ); ?>
+                                        </div>
+                                    <?php endif; ?>
+                                    <?php if ( $location_bits ) : ?>
+                                        <p class="moroccan-hero__location"><?php echo esc_html( implode( ', ', $location_bits ) ); ?></p>
+                                    <?php endif; ?>
+                                </header>
+                                <div class="moroccan-hero__details">
+                                    <?php if ( $rooms_total ) : ?>
+                                        <div class="moroccan-detail"><span class="label"><?php esc_html_e( 'Rooms', 'lbhotel' ); ?>:</span> <span class="value"><?php echo esc_html( $rooms_total ); ?></span></div>
+                                    <?php endif; ?>
+                                    <?php if ( $checkin || $checkout ) : ?>
+                                        <div class="moroccan-detail"><span class="label"><?php esc_html_e( 'Check-in / Check-out', 'lbhotel' ); ?>:</span> <span class="value"><?php echo esc_html( trim( $checkin . ' / ' . $checkout, ' /' ) ); ?></span></div>
+                                    <?php endif; ?>
+                                    <?php if ( $price_display ) : ?>
+                                        <div class="moroccan-detail moroccan-price"><span class="label"><?php esc_html_e( 'Average price per night', 'lbhotel' ); ?>:</span> <span class="value"><?php echo esc_html( $price_display ); ?></span></div>
+                                    <?php endif; ?>
+                                </div>
+                            </section>
+
+                            <?php if ( $gallery_ids ) : ?>
+                                <section class="moroccan-section moroccan-gallery" aria-label="<?php esc_attr_e( 'Hotel gallery', 'lbhotel' ); ?>">
+                                    <h2 class="moroccan-section__title"><?php esc_html_e( 'Gallery', 'lbhotel' ); ?></h2>
+                                    <div class="moroccan-gallery__grid" data-lightbox-gallery>
+                                        <?php foreach ( $gallery_ids as $attachment_id ) :
+                                            $image_url   = wp_get_attachment_image_url( $attachment_id, 'large' );
+                                            $image_thumb = wp_get_attachment_image_url( $attachment_id, 'medium_large' );
+                                            if ( ! $image_url ) {
+                                                continue;
+                                            }
+                                            ?>
+                                            <a href="<?php echo esc_url( $image_url ); ?>" class="moroccan-gallery__item" data-lightbox-item>
+                                                <img src="<?php echo esc_url( $image_thumb ? $image_thumb : $image_url ); ?>" alt="<?php echo esc_attr( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ); ?>" />
+                                            </a>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </section>
+                            <?php endif; ?>
+
+                            <?php if ( $tour_url ) : ?>
+                                <section class="moroccan-section moroccan-tour">
+                                    <h2 class="moroccan-section__title"><?php esc_html_e( 'Virtual Tour', 'lbhotel' ); ?></h2>
+                                    <div class="moroccan-iframe-wrapper">
+                                        <iframe src="<?php echo esc_url( $tour_url ); ?>" loading="lazy" allowfullscreen title="<?php esc_attr_e( 'Virtual tour', 'lbhotel' ); ?>"></iframe>
+                                    </div>
+                                </section>
+                            <?php endif; ?>
+
+                            <section class="moroccan-section moroccan-map" aria-label="<?php esc_attr_e( 'Hotel map', 'lbhotel' ); ?>">
+                                <h2 class="moroccan-section__title"><?php esc_html_e( 'Discover nearby delights', 'lbhotel' ); ?></h2>
+                                <div id="lbhotel-map" class="moroccan-map__canvas" data-current-hotel="<?php echo esc_attr( get_the_ID() ); ?>"></div>
+                            </section>
+
+                            <section class="moroccan-section moroccan-booking">
+                                <h2 class="moroccan-section__title"><?php esc_html_e( 'Book your stay', 'lbhotel' ); ?></h2>
+                                <?php if ( $booking_url ) : ?>
+                                    <div class="moroccan-iframe-wrapper">
+                                        <iframe src="<?php echo esc_url( $booking_url ); ?>" loading="lazy" title="<?php esc_attr_e( 'Booking', 'lbhotel' ); ?>"></iframe>
+                                    </div>
+                                <?php else : ?>
+                                    <p class="moroccan-placeholder"><?php esc_html_e( 'Booking information will be available soon. Contact the hotel directly for reservations.', 'lbhotel' ); ?></p>
+                                <?php endif; ?>
+                            </section>
+                        </div>
+                        <?php if ( function_exists( 'astra_entry_content_after' ) ) { astra_entry_content_after(); } ?>
+                    </article>
+                    <?php if ( function_exists( 'astra_entry_after' ) ) { astra_entry_after(); } ?>
+                <?php endwhile; ?>
+                <?php if ( function_exists( 'astra_primary_content_after' ) ) { astra_primary_content_after(); } ?>
+            </main>
+        </div>
+        <?php if ( function_exists( 'astra_primary_content_bottom' ) ) { astra_primary_content_bottom(); } ?>
+    </div>
 </div>
 
-<?php
-get_footer();
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- replace the single hotel template with an Astra-compatible layout that outputs full hotel details, gallery, virtual tour, map, and booking embed
- add a themed archive template with a filter bar, hotel cards, and pagination wrapped inside Astra's entry-content
- provide Moroccan-inspired styles and JavaScript for Leaflet mapping, gallery lightbox, and archive filtering

## Testing
- php -l single-lbhotel_hotel.php
- php -l archive-lbhotel_hotel.php

------
https://chatgpt.com/codex/tasks/task_e_68dd5e5461c083248db7cbada6050783