### PR TITLE
Add media picker for hotel gallery images and remove sample map data

### DIFF
--- a/admin/css/lbhotel-admin.css
+++ b/admin/css/lbhotel-admin.css
@@ -34,6 +34,57 @@
     width: 100%;
 }
 
+.lbhotel-gallery-field {
+    border: 1px solid #ccd0d4;
+    border-radius: 6px;
+    padding: 1rem;
+    background: #ffffff;
+    margin-top: 1rem;
+}
+
+.lbhotel-gallery-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.lbhotel-gallery-help {
+    color: #646970;
+}
+
+.lbhotel-gallery-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.lbhotel-gallery-item {
+    width: 120px;
+}
+
+.lbhotel-gallery-thumb {
+    border: 1px solid #dce3ec;
+    border-radius: 4px;
+    overflow: hidden;
+    background: #f8fafc;
+}
+
+.lbhotel-gallery-thumb img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.lbhotel-gallery-remove {
+    margin-top: 0.5rem;
+    color: #b32d2e;
+}
+
 .lbhotel-location-coordinates {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));

--- a/admin/js/lbhotel-admin.js
+++ b/admin/js/lbhotel-admin.js
@@ -4,81 +4,258 @@
     $(function () {
         var $container = $('#lbhotel-rooms-manager');
 
-        if (!$container.length) {
-            return;
-        }
+        if ($container.length) {
+            var $hidden = $('#lbhotel_rooms_json');
+            var roomIndex = $container.find('.lbhotel-room').length;
+            var addLabel = $container.data('locale-add') || 'Add room type';
+            var removeLabel = $container.data('locale-remove') || 'Remove';
 
-        var $hidden = $('#lbhotel_rooms_json');
-        var roomIndex = $container.find('.lbhotel-room').length;
-        var addLabel = $container.data('locale-add') || 'Add room type';
-        var removeLabel = $container.data('locale-remove') || 'Remove';
+            function syncRooms() {
+                var rooms = [];
 
-        function syncRooms() {
-            var rooms = [];
+                $container.find('.lbhotel-room').each(function () {
+                    var $room = $(this);
+                    var name = $room.find('.lbhotel-room-name').val().trim();
+                    var price = parseFloat($room.find('.lbhotel-room-price').val());
+                    var capacity = parseInt($room.find('.lbhotel-room-capacity').val(), 10);
+                    var availability = $room.find('.lbhotel-room-availability').val().trim();
+                    var imagesRaw = $room.find('.lbhotel-room-images').val();
+                    var images = imagesRaw ? imagesRaw.split(',').map(function (item) {
+                        return item.trim();
+                    }).filter(Boolean) : [];
 
-            $container.find('.lbhotel-room').each(function () {
-                var $room = $(this);
-                var name = $room.find('.lbhotel-room-name').val().trim();
-                var price = parseFloat($room.find('.lbhotel-room-price').val());
-                var capacity = parseInt($room.find('.lbhotel-room-capacity').val(), 10);
-                var availability = $room.find('.lbhotel-room-availability').val().trim();
-                var imagesRaw = $room.find('.lbhotel-room-images').val();
-                var images = imagesRaw ? imagesRaw.split(',').map(function (item) {
-                    return item.trim();
-                }).filter(Boolean) : [];
+                    if (!name) {
+                        return;
+                    }
 
-                if (!name) {
+                    rooms.push({
+                        name: name,
+                        price: isNaN(price) ? '' : price,
+                        capacity: isNaN(capacity) ? '' : capacity,
+                        availability: availability,
+                        images: images
+                    });
+                });
+
+                $hidden.val(JSON.stringify(rooms));
+            }
+
+            function resetRoom($room) {
+                $room.attr('data-index', roomIndex);
+                $room.find('input').val('');
+                $room.find('.lbhotel-remove-room').text(removeLabel);
+                roomIndex++;
+            }
+
+            $container.on('click', '.lbhotel-add-room', function (event) {
+                event.preventDefault();
+                var $rooms = $container.find('.lbhotel-room');
+                var $clone = $rooms.last().clone();
+                resetRoom($clone);
+                $clone.insertBefore($container.find('.lbhotel-add-room'));
+                syncRooms();
+            });
+
+            $container.on('click', '.lbhotel-remove-room', function (event) {
+                event.preventDefault();
+                var $rooms = $container.find('.lbhotel-room');
+                if ($rooms.length <= 1) {
+                    $rooms.find('input').val('');
+                    syncRooms();
                     return;
                 }
 
-                rooms.push({
-                    name: name,
-                    price: isNaN(price) ? '' : price,
-                    capacity: isNaN(capacity) ? '' : capacity,
-                    availability: availability,
-                    images: images
-                });
+                $(this).closest('.lbhotel-room').remove();
+                syncRooms();
             });
 
-            $hidden.val(JSON.stringify(rooms));
-        }
+            $container.on('keyup change', '.lbhotel-room input', syncRooms);
 
-        function resetRoom($room) {
-            $room.attr('data-index', roomIndex);
-            $room.find('input').val('');
-            $room.find('.lbhotel-remove-room').text(removeLabel);
-            roomIndex++;
-        }
-
-        $container.on('click', '.lbhotel-add-room', function (event) {
-            event.preventDefault();
-            var $rooms = $container.find('.lbhotel-room');
-            var $clone = $rooms.last().clone();
-            resetRoom($clone);
-            $clone.insertBefore($container.find('.lbhotel-add-room'));
-            syncRooms();
-        });
-
-        $container.on('click', '.lbhotel-remove-room', function (event) {
-            event.preventDefault();
-            var $rooms = $container.find('.lbhotel-room');
-            if ($rooms.length <= 1) {
-                $rooms.find('input').val('');
+            $('#post').on('submit', function () {
                 syncRooms();
-                return;
+            });
+
+            // Ensure initial state is synced.
+            syncRooms();
+        }
+
+        var $galleryField = $('#lbhotel-gallery-field');
+
+        if ($galleryField.length && typeof wp !== 'undefined' && wp.media && wp.media.attachment) {
+            var $galleryList = $galleryField.find('.lbhotel-gallery-list');
+            var $galleryInput = $('#lbhotel_gallery_images');
+            var $addButton = $galleryField.find('.lbhotel-gallery-add');
+            var $helpText = $galleryField.find('.lbhotel-gallery-help');
+            var maxImages = parseInt($galleryField.data('max'), 10) || 0;
+            var limitTemplate = ($helpText.data('limit-text') || '').toString();
+            var adminData = window.lbHotelAdmin && window.lbHotelAdmin.gallery ? window.lbHotelAdmin.gallery : {};
+            var frameTitle = adminData.frameTitle || 'Select images';
+            var frameButton = adminData.frameButton || 'Use images';
+            var removeText = adminData.removeImage || 'Remove';
+            var maxReachedText = adminData.maxReached || '';
+            var limitTemplateData = adminData.limitText || limitTemplate;
+            var frame;
+
+            if (adminData.maxImages) {
+                maxImages = parseInt(adminData.maxImages, 10) || maxImages;
             }
 
-            $(this).closest('.lbhotel-room').remove();
-            syncRooms();
-        });
+            if (limitTemplateData) {
+                limitTemplate = limitTemplateData;
+            }
 
-        $container.on('keyup change', '.lbhotel-room input', syncRooms);
+            function getIds() {
+                return $galleryList.find('.lbhotel-gallery-item').map(function () {
+                    return $(this).data('id').toString();
+                }).get();
+            }
 
-        $('#post').on('submit', function () {
-            syncRooms();
-        });
+            function updateHelp() {
+                if (!limitTemplate) {
+                    return;
+                }
 
-        // Ensure initial state is synced.
-        syncRooms();
+                var remaining = maxImages ? Math.max(0, maxImages - getIds().length) : 0;
+                var text = limitTemplate.replace('%1$d', maxImages).replace('%2$d', remaining);
+                $helpText.text(text);
+            }
+
+            function toggleAddButton() {
+                if (!maxImages) {
+                    return;
+                }
+
+                var disabled = getIds().length >= maxImages;
+                $addButton.prop('disabled', disabled);
+            }
+
+            function syncGallery() {
+                $galleryInput.val(getIds().join(','));
+                updateHelp();
+                toggleAddButton();
+            }
+
+            function appendImage(id, url) {
+                var existingIds = getIds();
+
+                if (existingIds.indexOf(id.toString()) !== -1) {
+                    return;
+                }
+
+                if (maxImages && existingIds.length >= maxImages) {
+                    return;
+                }
+
+                var $item = $('<li>', {
+                    'class': 'lbhotel-gallery-item',
+                    'data-id': id
+                });
+
+                var $thumb = $('<div>', { 'class': 'lbhotel-gallery-thumb' });
+                $('<img>', {
+                    src: url,
+                    alt: ''
+                }).appendTo($thumb);
+
+                var $remove = $('<button>', {
+                    type: 'button',
+                    'class': 'button-link lbhotel-gallery-remove',
+                    text: removeText
+                });
+
+                $item.append($thumb).append($remove);
+                $galleryList.append($item);
+            }
+
+            function openFrame() {
+                if (frame) {
+                    frame.open();
+                    return;
+                }
+
+                frame = wp.media({
+                    title: frameTitle,
+                    button: {
+                        text: frameButton
+                    },
+                    library: {
+                        type: 'image'
+                    },
+                    multiple: true
+                });
+
+                frame.on('open', function () {
+                    var selection = frame.state().get('selection');
+                    var ids = getIds();
+
+                    selection.reset();
+
+                    ids.forEach(function (id) {
+                        var attachment = wp.media.attachment(id);
+
+                        if (attachment) {
+                            attachment.fetch();
+                            selection.add(attachment);
+                        }
+                    });
+                });
+
+                frame.on('select', function () {
+                    var selection = frame.state().get('selection');
+                    var existing = getIds();
+
+                    selection.each(function (attachment) {
+                        var data = attachment.toJSON();
+                        var id = data && data.id ? data.id : null;
+
+                        if (!id) {
+                            return;
+                        }
+
+                        if (existing.indexOf(id.toString()) !== -1) {
+                            return;
+                        }
+
+                        if (maxImages && existing.length >= maxImages) {
+                            return;
+                        }
+
+                        var url = data && data.sizes && data.sizes.thumbnail ? data.sizes.thumbnail.url : data.url;
+
+                        if (!url) {
+                            return;
+                        }
+
+                        appendImage(id, url);
+                        existing.push(id.toString());
+                    });
+
+                    syncGallery();
+                });
+
+                frame.open();
+            }
+
+            $addButton.on('click', function (event) {
+                event.preventDefault();
+
+                if (maxImages && getIds().length >= maxImages) {
+                    if (maxReachedText) {
+                        window.alert(maxReachedText);
+                    }
+                    return;
+                }
+
+                openFrame();
+            });
+
+            $galleryField.on('click', '.lbhotel-gallery-remove', function (event) {
+                event.preventDefault();
+                $(this).closest('.lbhotel-gallery-item').remove();
+                syncGallery();
+            });
+
+            syncGallery();
+        }
     });
 })(jQuery);

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -59,11 +59,28 @@ function lbhotel_enqueue_admin_assets( $hook ) {
         wp_enqueue_style( 'lbhotel-admin' );
         wp_enqueue_script( 'lbhotel-admin' );
 
+        wp_enqueue_media();
+
         wp_localize_script(
             'lbhotel-admin',
             'lbHotelRooms',
             array(
                 'nonce' => wp_create_nonce( 'lbhotel_rooms_nonce' ),
+            )
+        );
+
+        wp_localize_script(
+            'lbhotel-admin',
+            'lbHotelAdmin',
+            array(
+                'gallery' => array(
+                    'frameTitle'  => __( 'Select gallery images', 'lbhotel' ),
+                    'frameButton' => __( 'Use images', 'lbhotel' ),
+                    'removeImage' => __( 'Remove', 'lbhotel' ),
+                    'limitText'   => __( 'You can add up to %1$d images. %2$d remaining.', 'lbhotel' ),
+                    'maxReached'  => __( 'You have reached the maximum number of gallery images.', 'lbhotel' ),
+                    'maxImages'   => lbhotel_get_gallery_max_images(),
+                ),
             )
         );
     }

--- a/single-hotel.js
+++ b/single-hotel.js
@@ -36,69 +36,26 @@
         };
     };
 
-    const buildDummyHotels = (currentHotel) => {
-        const samples = [
-            {
-                id: 'riad-atlas',
-                name: 'Riad Atlas Splendide',
-                city: 'Marrakech',
-                price: '€160 / night',
-                stars: 5,
-                lat: 31.6306,
-                lng: -7.9906,
-                bookingUrl: 'https://example.com/riad-atlas',
-                mapUrl: 'https://www.google.com/maps/search/?api=1&query=31.6306,-7.9906',
-                permalink: '#',
-                images: [
-                    'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=600&q=60',
-                    'https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=600&q=60',
-                ],
-            },
-            {
-                id: 'sahara-retreat',
-                name: 'Sahara Retreat & Spa',
-                city: 'Merzouga',
-                price: '€220 / night',
-                stars: 4,
-                lat: 31.0994,
-                lng: -4.0127,
-                bookingUrl: 'https://example.com/sahara-retreat',
-                mapUrl: 'https://www.google.com/maps/search/?api=1&query=31.0994,-4.0127',
-                permalink: '#',
-                images: [
-                    'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=600&q=60',
-                    'https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?auto=format&fit=crop&w=600&q=60',
-                ],
-            },
-            {
-                id: 'chefchaouen-lights',
-                name: 'Chefchaouen Lights Riad',
-                city: 'Chefchaouen',
-                price: '€140 / night',
-                stars: 4,
-                lat: 35.1714,
-                lng: -5.2697,
-                bookingUrl: 'https://example.com/chefchaouen-lights',
-                mapUrl: 'https://www.google.com/maps/search/?api=1&query=35.1714,-5.2697',
-                permalink: '#',
-                images: [
-                    'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=600&q=60',
-                    'https://images.unsplash.com/photo-1496317899792-9d7dbcd928a1?auto=format&fit=crop&w=600&q=60',
-                ],
-            },
-        ];
+    const collectHotels = (data) => {
+        const hotels = [];
 
-        const hotels = samples.map(normaliseHotel).filter(Boolean);
+        if (data) {
+            const list = Array.isArray(data.hotels) ? data.hotels : [];
+            list
+                .map(normaliseHotel)
+                .filter(Boolean)
+                .forEach((hotel) => hotels.push(hotel));
 
-        const current = normaliseHotel(currentHotel);
-        if (current) {
-            const alreadyPresent = hotels.some((hotel) => hotel.id === current.id || (hotel.lat === current.lat && hotel.lng === current.lng));
-            if (!alreadyPresent) {
-                hotels.push(current);
-            } else {
-                const index = hotels.findIndex((hotel) => hotel.id === current.id);
-                if (index >= 0) {
-                    hotels[index] = { ...hotels[index], ...current };
+            const current = normaliseHotel(data.currentHotel);
+            if (current) {
+                const existingIndex = hotels.findIndex(
+                    (hotel) => hotel.id === current.id || (hotel.lat === current.lat && hotel.lng === current.lng)
+                );
+
+                if (existingIndex >= 0) {
+                    hotels[existingIndex] = { ...hotels[existingIndex], ...current };
+                } else {
+                    hotels.push(current);
                 }
             }
         }
@@ -258,7 +215,7 @@
 
         const data = window.lbHotelSingleData || {};
         const fallback = data.fallbackCenter || { lat: 31.7917, lng: -7.0926 };
-        const hotels = buildDummyHotels(data.currentHotel);
+        const hotels = collectHotels(data);
 
         const startHotel = normaliseHotel(data.currentHotel);
         const initialLat = Number.isFinite(startHotel?.lat) ? startHotel.lat : fallback.lat;


### PR DESCRIPTION
## Summary
- replace the hotel gallery meta box field with an inline media picker that shows thumbnails and limits selections to five images
- add styling and JavaScript to manage the gallery UI and sync the selected attachment IDs back to the hidden field
- enqueue the WordPress media library and expose translated strings/configuration for the gallery selector
- remove hard-coded example hotel data from the single-hotel map script so only localized hotels are displayed

## Testing
- php -l includes/admin-meta.php
- php -l includes/assets.php

------
https://chatgpt.com/codex/tasks/task_e_68debacb04c08324be95c487e89de7e9