### PR TITLE
Adjust map popups for mobile and desktop layouts

### DIFF
--- a/single-hotel.css
+++ b/single-hotel.css
@@ -301,11 +301,22 @@ body.single-lbhotel_hotel .site-content,
     width: 100%;
 }
 
-.lbhotel-popup {
+.lbhotel-popup { 
     max-width: 260px;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+}
+
+.lbhotel-popup__image {
+    width: 100%;
+    overflow: hidden;
+}
+
+.lbhotel-popup__image img {
+    width: 100%;
+    height: auto;
+    display: block;
 }
 
 .lbhotel-popup h3 {
@@ -334,6 +345,22 @@ body.single-lbhotel_hotel .site-content,
     width: 100%;
     font-size: 0.75rem;
     padding: 0.45rem 0.75rem !important;
+}
+
+@media (max-width: 768px) {
+    .lbhotel-popup {
+        max-width: 220px;
+        gap: 0.5rem;
+    }
+
+    .lbhotel-popup__meta {
+        font-size: 0.85rem;
+    }
+
+    .lbhotel-popup__actions,
+    .lbhotel-popup-actions {
+        display: none;
+    }
 }
 
 @media (max-width: 1024px) {

--- a/single-hotel.js
+++ b/single-hotel.js
@@ -98,29 +98,37 @@
     };
 
     const buildPopupContent = (hotel) => {
-        const slider = buildSliderMarkup(hotel);
+        const isDesktop = typeof window === 'undefined' ? true : window.innerWidth > 768;
         const meta = [hotel.city, hotel.price].filter(Boolean).join(' · ');
         const stars = hotel.stars > 0 ? '★'.repeat(Math.min(5, hotel.stars)) : '';
 
-        const buttons = [
-            hotel.bookingUrl
-                ? `<a class="lbhotel-button lbhotel-button--reserve" href="${escapeHtml(hotel.bookingUrl)}" target="_blank" rel="noopener noreferrer">Reserve Booking</a>`
-                : '',
-            hotel.mapUrl
-                ? `<a class="lbhotel-button lbhotel-button--map" href="${escapeHtml(hotel.mapUrl)}" target="_blank" rel="noopener noreferrer">Show in Google Map</a>`
-                : '',
-            `<a class="lbhotel-button lbhotel-button--details" href="${escapeHtml(hotel.permalink)}">View Details</a>`,
-        ]
-            .filter(Boolean)
-            .join('');
+        const media = isDesktop
+            ? buildSliderMarkup(hotel)
+            : hotel.images && hotel.images.length > 0
+                ? `<div class="lbhotel-popup__image"><img src="${escapeHtml(hotel.images[0])}" alt="${escapeHtml(hotel.name)}" /></div>`
+                : '';
+
+        const actions = isDesktop
+            ? [
+                  hotel.bookingUrl
+                      ? `<a class="lbhotel-button lbhotel-button--reserve" href="${escapeHtml(hotel.bookingUrl)}" target="_blank" rel="noopener noreferrer">Reserve Booking</a>`
+                      : '',
+                  hotel.mapUrl
+                      ? `<a class="lbhotel-button lbhotel-button--map" href="${escapeHtml(hotel.mapUrl)}" target="_blank" rel="noopener noreferrer">Show in Google Map</a>`
+                      : '',
+                  `<a class="lbhotel-button lbhotel-button--details" href="${escapeHtml(hotel.permalink)}">View Details</a>`,
+              ]
+                  .filter(Boolean)
+                  .join('')
+            : '';
 
         return `
         <div class="lbhotel-popup">
             <h3>${escapeHtml(hotel.name)}</h3>
-            ${slider}
+            ${media}
             ${meta ? `<p class="lbhotel-popup__meta">${escapeHtml(meta)}</p>` : ''}
             ${stars ? `<div class="lbhotel-popup__stars">${escapeHtml(stars)}</div>` : ''}
-            <div class="lbhotel-popup__actions">${buttons}</div>
+            ${actions ? `<div class="lbhotel-popup__actions">${actions}</div>` : ''}
         </div>`;
     };
     const setupSliders = (root = document) => {


### PR DESCRIPTION
## Summary
- update the single hotel map popup builder to render full content on desktop and a condensed version on mobile
- add supporting popup image styles and mobile media query rules to keep the compact layout tidy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0e9570cc8324b688f90e18766cea