### PR TITLE
Render live hotel cards on archive template

### DIFF
--- a/all-hotel.css
+++ b/all-hotel.css
@@ -2,17 +2,17 @@
     --moroccan-red: #c1272d;
     --moroccan-green: #006233;
     --moroccan-cream: #fff9f2;
-    --moroccan-shadow: rgba(0, 0, 0, 0.08);
+    --moroccan-sand: #f4e8d5;
+    --moroccan-shadow: rgba(0, 0, 0, 0.12);
     --text-dark: #1e1e1e;
     --text-light: #ffffff;
-    --card-radius: 18px;
 }
 
-body {
-    background-color: var(--moroccan-cream);
-    background-image: repeating-linear-gradient(45deg, rgba(193, 39, 45, 0.05) 0 20px, rgba(0, 98, 51, 0.05) 20px 40px),
-        radial-gradient(circle at 20% 20%, rgba(193, 39, 45, 0.12) 0, rgba(193, 39, 45, 0) 55%),
-        radial-gradient(circle at 80% 0%, rgba(0, 98, 51, 0.15) 0, rgba(0, 98, 51, 0) 60%);
+body.archive.post-type-archive-lbhotel_hotel {
+    background: var(--moroccan-cream);
+    background-image: radial-gradient(circle at 8% 20%, rgba(193, 39, 45, 0.12) 0, rgba(193, 39, 45, 0) 50%),
+        radial-gradient(circle at 90% 10%, rgba(0, 98, 51, 0.15) 0, rgba(0, 98, 51, 0) 55%),
+        repeating-linear-gradient(135deg, rgba(244, 232, 213, 0.8) 0 14px, rgba(244, 232, 213, 0.55) 14px 28px);
     background-attachment: fixed;
     font-family: 'Poppins', 'Montserrat', 'Helvetica Neue', Arial, sans-serif;
     color: var(--text-dark);
@@ -20,406 +20,350 @@ body {
 
 [data-all-hotels-page] {
     position: relative;
-    padding-top: 3rem;
-    padding-bottom: 4rem;
+    padding: 3rem 0 4rem;
 }
 
-.all-hotels {
-    position: relative;
+.lbhotel-all-hotels {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 2rem;
 }
 
-.all-hotels__filters {
-    position: relative;
-    top: 0;
-    width: 100%;
-    z-index: 2;
-    display: flex;
-    align-items: stretch;
+.lbhotel-archive__header {
+    text-align: center;
+    padding: 1.5rem 1rem 0;
 }
 
-.all-hotels__filters-form {
-    position: relative;
-    width: 100%;
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.5rem;
-    padding: 0 1rem;
-    background: var(--moroccan-red);
-    box-shadow: 0 6px 18px rgba(193, 39, 45, 0.25);
-    border-radius: 18px;
-}
-
-.all-hotels__field {
-    display: flex;
-    align-items: center;
-}
-
-.all-hotels__field input,
-.all-hotels__field select {
-    width: 100%;
-    height: 100%;
-    border: none;
-    padding: 0 0.75rem;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.95);
-    color: var(--text-dark);
-    font-size: 0.9rem;
-    font-weight: 500;
-    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
-}
-
-.all-hotels__field select {
-    appearance: none;
-    background-image: linear-gradient(45deg, transparent 50%, var(--moroccan-red) 50%),
-        linear-gradient(135deg, var(--moroccan-red) 50%, transparent 50%);
-    background-position: calc(100% - 18px) calc(1rem), calc(100% - 12px) calc(1rem);
-    background-size: 6px 6px;
-    background-repeat: no-repeat;
-    padding-right: 2.5rem;
-}
-
-.all-hotels__sorting {
-    position: relative;
-    z-index: 1;
-    width: 100%;
-    margin-top: 1rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.25rem 1.5rem;
-    background: var(--moroccan-red);
-    color: var(--text-light);
-    border-radius: 18px;
-    box-shadow: 0 12px 25px rgba(0, 0, 0, 0.12);
-}
-
-.all-hotels__results {
-    display: flex;
-    align-items: baseline;
-    gap: 0.5rem;
-    font-size: 1rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-}
-
-.all-hotels__results span:first-child {
-    font-size: 1.25rem;
-}
-
-.all-hotels__sort {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-}
-
-.all-hotels__sort-label {
+.lbhotel-archive__title {
+    margin: 0;
+    font-size: clamp(2rem, 3vw, 2.6rem);
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    font-size: 0.75rem;
-    font-weight: 600;
-}
-
-.all-hotels__sort select {
-    border-radius: 999px;
-    border: none;
-    padding: 0.35rem 1.5rem 0.35rem 0.75rem;
-    font-weight: 600;
     color: var(--moroccan-red);
-    background: var(--text-light);
-    cursor: pointer;
 }
 
-.all-hotels__list {
+.lbhotel-archive__intro {
+    margin: 0.75rem auto 0;
+    max-width: 640px;
+    font-size: 1rem;
+    line-height: 1.7;
+    color: rgba(30, 30, 30, 0.72);
+}
+
+.lbhotel-archive__list {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: 1.75rem;
+    padding: 0 0.5rem;
 }
 
-.hotel-card {
+.lbhotel-archive-card {
     display: grid;
-    grid-template-columns: 30% 1fr 20%;
+    grid-template-columns: minmax(260px, 30%) minmax(0, 1fr) minmax(200px, 20%);
     align-items: stretch;
     min-height: 20vh;
-    background: #ffffff;
-    border-radius: var(--card-radius);
+    background: var(--text-light);
+    border-radius: 20px;
     overflow: hidden;
-    box-shadow: 0 18px 35px var(--moroccan-shadow);
+    box-shadow: 0 18px 40px var(--moroccan-shadow);
     border: 1px solid rgba(0, 0, 0, 0.05);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    transition: transform 0.35s ease, box-shadow 0.35s ease;
 }
 
-.hotel-card:hover {
+.lbhotel-archive-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 26px 40px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 26px 48px rgba(0, 0, 0, 0.16);
 }
 
-.hotel-card__slider {
+.lbhotel-archive-card__media {
     position: relative;
+    min-height: 20vh;
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.lbhotel-slider {
+    position: relative;
+    width: 100%;
     height: 100%;
     overflow: hidden;
+    background: rgba(0, 0, 0, 0.06);
 }
 
-.hotel-card__slider--empty {
+.lbhotel-slider__track {
+    display: flex;
+    height: 100%;
+    transition: transform 0.5s ease;
+}
+
+.lbhotel-slider__slide {
+    flex: 0 0 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1.5rem;
-    text-align: center;
-    background: linear-gradient(135deg, rgba(193, 39, 45, 0.9), rgba(0, 98, 51, 0.85));
-    color: var(--text-light);
-    min-height: 100%;
-    width: 100%;
+    background: rgba(0, 0, 0, 0.05);
 }
 
-.hotel-card__slider-empty-text {
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-}
-
-.hotel-card__slides {
-    display: flex;
+.lbhotel-slider__slide img {
     width: 100%;
     height: 100%;
-    transition: transform 0.6s ease-in-out;
+    object-fit: cover;
 }
 
-.hotel-card__slide {
-    flex: 1 0 100%;
-    height: 100%;
-    background-position: center;
-    background-size: cover;
-}
-
-.hotel-card__slider-dots {
+.lbhotel-slider__nav {
     position: absolute;
-    left: 50%;
-    bottom: 0.75rem;
-    transform: translateX(-50%);
-    display: flex;
-    gap: 0.25rem;
-}
-
-.hotel-card__dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.6);
-    border: 1px solid rgba(0, 0, 0, 0.12);
+    top: 50%;
+    transform: translateY(-50%);
+    width: 2.5rem;
+    height: 2.5rem;
+    border: none;
+    border-radius: 999px;
+    background: rgba(193, 39, 45, 0.85);
+    color: var(--text-light);
+    font-size: 1.25rem;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
     transition: background 0.3s ease, transform 0.3s ease;
 }
 
-.hotel-card__dot.is-active {
-    background: var(--moroccan-green);
-    transform: scale(1.3);
+.lbhotel-slider__nav:hover,
+.lbhotel-slider__nav:focus-visible {
+    background: rgba(0, 98, 51, 0.9);
+    transform: translateY(-50%) scale(1.05);
 }
 
-.hotel-card__info {
-    padding: 1.5rem;
+.lbhotel-slider__nav--prev {
+    left: 0.75rem;
+}
+
+.lbhotel-slider__nav--next {
+    right: 0.75rem;
+}
+
+.lbhotel-slider__dots {
+    position: absolute;
+    left: 50%;
+    bottom: 0.9rem;
+    transform: translateX(-50%);
+    display: inline-flex;
+    gap: 0.4rem;
+    background: rgba(255, 255, 255, 0.65);
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+}
+
+.lbhotel-slider__dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 50%;
+    border: none;
+    background: rgba(0, 0, 0, 0.25);
+    cursor: pointer;
+    transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.lbhotel-slider__dot.is-active {
+    background: var(--moroccan-green);
+    transform: scale(1.2);
+}
+
+.lbhotel-slider--empty {
+    display: grid;
+    place-items: center;
+    height: 100%;
+    color: rgba(30, 30, 30, 0.6);
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 2rem 1.5rem;
+    text-align: center;
+    background: linear-gradient(135deg, rgba(193, 39, 45, 0.85), rgba(0, 98, 51, 0.75));
+    color: var(--text-light);
+}
+
+.lbhotel-archive-card__content {
+    padding: 1.75rem 2rem;
     display: flex;
     flex-direction: column;
-    gap: 0.65rem;
+    gap: 0.6rem;
+    justify-content: center;
 }
 
-.hotel-card__name {
-    font-size: 1.35rem;
-    font-weight: 700;
-    color: var(--moroccan-red);
+.lbhotel-archive-card__title {
     margin: 0;
-}
-
-.hotel-card__location {
-    font-size: 0.95rem;
-    color: rgba(30, 30, 30, 0.7);
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-}
-
-.hotel-card__stars {
-    color: #f6b93b;
-    letter-spacing: 0.1em;
-    font-size: 1.1rem;
-}
-
-.hotel-card__price {
-    font-size: 1rem;
+    font-size: 1.65rem;
     font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.lbhotel-archive-card__title a {
+    color: var(--moroccan-red);
+    text-decoration: none;
+}
+
+.lbhotel-archive-card__title a:hover,
+.lbhotel-archive-card__title a:focus-visible {
     color: var(--moroccan-green);
 }
 
-.hotel-card__description {
+.lbhotel-archive-card__location {
     margin: 0;
-    font-size: 0.9rem;
-    line-height: 1.6;
+    font-size: 0.95rem;
+    letter-spacing: 0.05em;
     color: rgba(30, 30, 30, 0.7);
 }
 
-.hotel-card__actions {
-    background: linear-gradient(180deg, rgba(193, 39, 45, 0.08) 0%, rgba(0, 98, 51, 0.08) 100%);
+.lbhotel-archive-card__stars {
+    display: inline-flex;
+    gap: 0.35rem;
+    font-size: 1.1rem;
+    color: #f6b93b;
+}
+
+.lbhotel-archive-card__price {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--moroccan-green);
+}
+
+.lbhotel-archive-card__actions {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 0.75rem;
+    gap: 0.85rem;
     padding: 1.5rem;
+    background: linear-gradient(180deg, rgba(193, 39, 45, 0.08) 0%, rgba(0, 98, 51, 0.08) 100%);
 }
 
-.hotel-card__button {
-    border: none;
+.lbhotel-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.25rem;
     border-radius: 999px;
+    border: none;
     font-weight: 700;
-    font-size: 0.9rem;
-    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
     text-decoration: none;
-    text-align: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
-.hotel-card__button:hover,
-.hotel-card__button:focus-visible {
+.lbhotel-button:hover,
+.lbhotel-button:focus-visible {
     transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
 }
 
-.hotel-card__button--reserve {
+.lbhotel-button--reserve {
     background: var(--moroccan-green);
     color: var(--text-light);
 }
 
-.hotel-card__button--reserve:hover,
-.hotel-card__button--reserve:focus-visible {
-    filter: brightness(0.9);
+.lbhotel-button--reserve:hover,
+.lbhotel-button--reserve:focus-visible {
+    filter: brightness(0.92);
 }
 
-.hotel-card__button--map {
+.lbhotel-button--map {
     background: var(--moroccan-red);
     color: var(--text-light);
 }
 
-.hotel-card__button--map:hover,
-.hotel-card__button--map:focus-visible {
+.lbhotel-button--map:hover,
+.lbhotel-button--map:focus-visible {
     filter: brightness(0.9);
 }
 
-.hotel-card__button--details {
+.lbhotel-button--details {
     background: linear-gradient(135deg, var(--moroccan-red), var(--moroccan-green));
     color: var(--text-light);
-    box-shadow: 0 12px 22px rgba(0, 0, 0, 0.15);
 }
 
-.hotel-card__button--details:hover,
-.hotel-card__button--details:focus-visible {
+.lbhotel-button--details:hover,
+.lbhotel-button--details:focus-visible {
     box-shadow: 0 0 18px rgba(0, 98, 51, 0.35);
 }
 
-.all-hotels__pagination {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    padding-top: 1rem;
-}
-
-.all-hotels__pagination-button {
-    border: none;
-    border-radius: 999px;
-    background: var(--moroccan-green);
-    color: var(--text-light);
+.lbhotel-archive__empty {
+    margin: 3rem auto 0;
+    max-width: 640px;
+    text-align: center;
+    padding: 2.25rem;
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.08);
     font-weight: 600;
-    padding: 0.65rem 1.5rem;
-    cursor: pointer;
-    transition: transform 0.2s ease, filter 0.2s ease;
+    letter-spacing: 0.05em;
+    color: var(--moroccan-red);
 }
 
-.all-hotels__pagination-button:hover,
-.all-hotels__pagination-button:focus-visible {
-    filter: brightness(0.9);
-    transform: translateY(-2px);
-}
-
-.all-hotels__pagination-button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
-}
-
-@media (max-width: 1024px) {
-    .all-hotels__filters-form {
-        grid-template-columns: 1fr;
-        height: auto;
-        padding: 0.75rem 1rem;
+@media (max-width: 1080px) {
+    .lbhotel-archive-card {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     }
 
-    .all-hotels__filters {
-        height: auto;
-        padding-bottom: 0.5rem;
-    }
-
-    .all-hotels__sorting {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 0.75rem;
-        border-radius: 18px;
-    }
-
-    .hotel-card {
-        grid-template-columns: 1fr;
-        min-height: auto;
-    }
-
-    .hotel-card__slider {
-        height: 220px;
-    }
-
-    .hotel-card__actions {
+    .lbhotel-archive-card__actions {
+        grid-column: 1 / -1;
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: center;
     }
 
-    .hotel-card__button {
-        flex: 1 1 45%;
+    .lbhotel-archive-card__actions .lbhotel-button {
+        flex: 1 1 30%;
+        min-width: 180px;
     }
 }
 
-@media (max-width: 640px) {
-    .all-hotels__filters-form {
-        padding: 0.75rem 1rem;
-        border-radius: 18px;
+@media (max-width: 768px) {
+    [data-all-hotels-page] {
+        padding: 2.5rem 0 3.5rem;
     }
 
-    .all-hotels__filters {
-        height: auto;
+    .lbhotel-archive__intro {
+        font-size: 0.95rem;
+        padding: 0 1.25rem;
     }
 
-    .all-hotels__sorting {
-        margin-top: 1rem;
+    .lbhotel-archive-card {
+        grid-template-columns: 1fr;
     }
 
-    .hotel-card__slider {
-        height: 180px;
+    .lbhotel-archive-card__media {
+        min-height: 220px;
     }
 
-    .hotel-card__actions {
-        flex-direction: column;
+    .lbhotel-archive-card__content {
+        padding: 1.5rem 1.75rem;
+        text-align: center;
     }
 
-    .hotel-card__button {
+    .lbhotel-archive-card__actions {
+        padding: 1.5rem 1.75rem 2rem;
+        gap: 0.75rem;
+    }
+
+    .lbhotel-archive-card__actions .lbhotel-button {
         width: 100%;
     }
 }
 
-.hotel-card__empty {
-    padding: 2.5rem;
-    text-align: center;
-    background: rgba(255, 255, 255, 0.85);
-    border-radius: var(--card-radius);
-    font-weight: 600;
-    letter-spacing: 0.03em;
-    color: var(--moroccan-red);
-    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+@media (max-width: 480px) {
+    .lbhotel-archive__title {
+        letter-spacing: 0.05em;
+    }
+
+    .lbhotel-archive-card__media {
+        min-height: 200px;
+    }
+
+    .lbhotel-slider__nav {
+        width: 2.1rem;
+        height: 2.1rem;
+        font-size: 1.05rem;
+    }
 }

--- a/all-hotel.js
+++ b/all-hotel.js
@@ -1,471 +1,103 @@
 (function () {
-    const localized = window.lbhotelAllHotels || {};
+    const sliderSelector = '[data-lbhotel-slider]';
 
-    const defaultStrings = {
-        empty: 'No hotels match your search. Try adjusting filters.',
-        emptyPage: 'No more hotels on this page.',
-        reserve: 'Reserve Booking',
-        map: 'Show on Map',
-        details: 'View Details',
-        priceLabel: '/ night',
-        noImage: 'Image coming soon',
-        imageAlt: 'Hotel gallery image',
-    };
-
-    const strings = Object.assign({}, defaultStrings, localized.strings || {});
-
-    const defaultCurrency =
-        typeof localized.currency === 'string' && localized.currency ? localized.currency : 'USD';
-
-    const perPageValue = Number(localized.perPage);
-    const normalizedPerPage = Number.isFinite(perPageValue) && perPageValue > 0 ? perPageValue : 4;
-
-    function normalizeHotel(rawHotel, index) {
-        if (!rawHotel || typeof rawHotel !== 'object') {
-            return null;
-        }
-
-        const normalized = {
-            id: rawHotel.id || rawHotel.ID || index + 1,
-            name: rawHotel.name || rawHotel.title || '',
-            city: rawHotel.city || '',
-            region: rawHotel.region || '',
-            country: rawHotel.country || '',
-            description: rawHotel.description || rawHotel.excerpt || '',
-            booking_url: rawHotel.booking_url || '',
-            details_url: rawHotel.details_url || rawHotel.permalink || '',
-            available_from: rawHotel.available_from || rawHotel.published_at || rawHotel.date || '',
-        };
-
-        const ratingValue = parseFloat(rawHotel.rating);
-        normalized.rating = Number.isNaN(ratingValue) ? null : ratingValue;
-
-        const priceValue = parseFloat(rawHotel.price);
-        normalized.price = Number.isNaN(priceValue) ? null : priceValue;
-
-        const distanceValue = parseFloat(rawHotel.distance);
-        normalized.distance = Number.isNaN(distanceValue) ? null : distanceValue;
-
-        const coordsSource = rawHotel.coordinates || {};
-        const lat = parseFloat(coordsSource.lat);
-        const lng = parseFloat(coordsSource.lng);
-        normalized.coordinates = !Number.isNaN(lat) && !Number.isNaN(lng) ? { lat, lng } : null;
-
-        const images = Array.isArray(rawHotel.images) ? rawHotel.images : [];
-        const sanitizedImages = images
-            .map((image) => (typeof image === 'string' ? image.trim() : ''))
-            .filter((image) => image.length > 0);
-
-        if (sanitizedImages.length === 0 && typeof rawHotel.featured_image === 'string' && rawHotel.featured_image) {
-            sanitizedImages.push(rawHotel.featured_image);
-        }
-
-        normalized.images = sanitizedImages;
-
-        const dateValue = Date.parse(normalized.available_from);
-        normalized._sortDate = Number.isNaN(dateValue) ? 0 : dateValue;
-
-        return normalized;
-    }
-
-    const HOTELS = Array.isArray(localized.hotels)
-        ? localized.hotels.map(normalizeHotel).filter(Boolean)
-        : [];
-
-    const state = {
-        search: '',
-        distance: 'all',
-        rating: 'all',
-        sort: 'date-desc',
-        page: 1,
-        perPage: normalizedPerPage,
-    };
-
-    const selectors = {
-        search: document.getElementById('hotel-search'),
-        distance: document.getElementById('hotel-distance'),
-        rating: document.getElementById('hotel-rating'),
-        sort: document.getElementById('hotel-sort'),
-        list: document.getElementById('hotel-list'),
-        count: document.querySelector('[data-hotel-count]'),
-        paginationButtons: document.querySelectorAll('[data-pagination]'),
-    };
-
-    const sliderIntervals = new Map();
-
-    function normalizeString(value) {
-        if (typeof value === 'string') {
-            return value.toLowerCase().trim();
-        }
-
-        if (typeof value === 'number') {
-            return String(value).toLowerCase().trim();
-        }
-
-        return '';
-    }
-
-    function applyFilters(hotels) {
-        return hotels.filter((hotel) => {
-            const searchMatch =
-                !state.search ||
-                [hotel.name, hotel.city, hotel.region, hotel.country, hotel.description]
-                    .map(normalizeString)
-                    .some((value) => value.includes(state.search));
-
-            const distanceMatch =
-                state.distance === 'all' ||
-                (typeof hotel.distance === 'number' && hotel.distance <= Number(state.distance));
-
-            const ratingMatch =
-                state.rating === 'all' ||
-                (typeof hotel.rating === 'number' && hotel.rating >= Number(state.rating));
-
-            return searchMatch && distanceMatch && ratingMatch;
-        });
-    }
-
-    function applySort(hotels) {
-        const sorted = [...hotels];
-        const [field, direction] = state.sort.split('-');
-
-        sorted.sort((a, b) => {
-            let compare = 0;
-
-            switch (field) {
-                case 'date':
-                    compare = (a._sortDate || 0) - (b._sortDate || 0);
-                    break;
-                case 'distance': {
-                    const aDistance = typeof a.distance === 'number' ? a.distance : Number.POSITIVE_INFINITY;
-                    const bDistance = typeof b.distance === 'number' ? b.distance : Number.POSITIVE_INFINITY;
-                    compare = aDistance - bDistance;
-                    break;
-                }
-                case 'rating': {
-                    const aRating = typeof a.rating === 'number' ? a.rating : 0;
-                    const bRating = typeof b.rating === 'number' ? b.rating : 0;
-                    compare = aRating - bRating;
-                    break;
-                }
-                default:
-                    compare = 0;
-            }
-
-            return direction === 'asc' ? compare : -compare;
-        });
-
-        return sorted;
-    }
-
-    function paginate(hotels) {
-        const start = (state.page - 1) * state.perPage;
-        return hotels.slice(start, start + state.perPage);
-    }
-
-    function formatPrice(price) {
-        if (typeof price !== 'number' || Number.isNaN(price)) {
-            return '';
-        }
-
-        try {
-            return new Intl.NumberFormat(undefined, {
-                style: 'currency',
-                currency: defaultCurrency,
-                minimumFractionDigits: 0,
-            }).format(price);
-        } catch (error) {
-            return price.toFixed(0);
-        }
-    }
-
-    function createStarRating(rating) {
-        if (typeof rating !== 'number' || Number.isNaN(rating) || rating <= 0) {
-            return '';
-        }
-
-        const clampedRating = Math.max(0, Math.min(5, Math.round(rating)));
-        const fullStars = '★'.repeat(clampedRating);
-
-        return `<span class="hotel-card__stars" aria-label="${clampedRating} star rating">${fullStars}</span>`;
-    }
-
-    function createSlider(images, hotelId) {
-        if (!Array.isArray(images) || images.length === 0) {
-            return `
-                <div class="hotel-card__slider hotel-card__slider--empty" aria-hidden="true">
-                    <div class="hotel-card__slider-empty-text">${strings.noImage}</div>
-                </div>
-            `;
-        }
-
-        const slides = images
-            .map(
-                (image) =>
-                    `<div class="hotel-card__slide" style="background-image:url('${image}')" role="img" aria-label="${strings.imageAlt}"></div>`
-            )
-            .join('');
-
-        const dots =
-            images.length > 1
-                ? images
-                      .map(
-                          (_, index) =>
-                              `<span class="hotel-card__dot${index === 0 ? ' is-active' : ''}" data-dot="${index}"></span>`
-                      )
-                      .join('')
-                : '';
-
-        const dotsMarkup =
-            dots && dots.length
-                ? `<div class="hotel-card__slider-dots" role="tablist">${dots}</div>`
-                : '';
-
-        return `
-            <div class="hotel-card__slider" data-slider="${hotelId}">
-                <div class="hotel-card__slides" data-slides>${slides}</div>
-                ${dotsMarkup}
-            </div>
-        `;
-    }
-
-    function createCard(hotel) {
-        const regionCountry = [hotel.region, hotel.country].filter(Boolean).join(', ');
-        const hasCity = Boolean(hotel.city);
-        const hasRegionCountry = regionCountry.length > 0;
-        const hasCoordinates = hotel.coordinates && typeof hotel.coordinates.lat === 'number' && typeof hotel.coordinates.lng === 'number';
-
-        let locationMarkup = '';
-
-        if (hasCity || hasRegionCountry) {
-            const bullet = hasCity && hasRegionCountry ? '<span>•</span>' : '';
-            const cityMarkup = hasCity ? `<span>${hotel.city}</span>` : '';
-            const regionMarkup = hasRegionCountry ? `<span>${regionCountry}</span>` : '';
-
-            locationMarkup = `
-                <div class="hotel-card__location">
-                    ${cityMarkup}
-                    ${bullet}
-                    ${regionMarkup}
-                </div>
-            `;
-        }
-
-        const priceMarkup = hotel.price !== null ? `<div class="hotel-card__price">${formatPrice(hotel.price)} <span>${strings.priceLabel}</span></div>` : '';
-        const descriptionMarkup = hotel.description
-            ? `<p class="hotel-card__description">${hotel.description}</p>`
-            : '';
-
-        const mapUrl = hasCoordinates
-            ? `https://www.google.com/maps/search/?api=1&query=${hotel.coordinates.lat},${hotel.coordinates.lng}`
-            : '';
-
-        const actions = [
-            hotel.booking_url
-                ? `<a class="hotel-card__button hotel-card__button--reserve" href="${hotel.booking_url}" target="_blank" rel="noopener">${strings.reserve}</a>`
-                : '',
-            hasCoordinates
-                ? `<a class="hotel-card__button hotel-card__button--map" href="${mapUrl}" target="_blank" rel="noopener">${strings.map}</a>`
-                : '',
-            hotel.details_url
-                ? `<a class="hotel-card__button hotel-card__button--details" href="${hotel.details_url}">${strings.details}</a>`
-                : '',
-        ]
-            .filter(Boolean)
-            .join('');
-
-        return `
-            <article class="hotel-card" data-hotel-id="${hotel.id}">
-                ${createSlider(hotel.images, hotel.id)}
-                <div class="hotel-card__info">
-                    <h2 class="hotel-card__name">${hotel.name}</h2>
-                    ${locationMarkup}
-                    ${createStarRating(hotel.rating)}
-                    ${priceMarkup}
-                    ${descriptionMarkup}
-                </div>
-                <div class="hotel-card__actions">
-                    ${actions}
-                </div>
-            </article>
-        `;
-    }
-
-    function clearSliders() {
-        sliderIntervals.forEach((intervalId) => window.clearInterval(intervalId));
-        sliderIntervals.clear();
-    }
-
-    function initSlider(container) {
-        const slidesWrapper = container.querySelector('[data-slides]');
-        const dots = container.querySelectorAll('.hotel-card__dot');
-
-        if (!slidesWrapper) {
+    function setupSlider(slider) {
+        if (!slider || slider.dataset.lbhotelSliderInitialised) {
             return;
         }
 
-        const sliderId = container.dataset.slider;
+        const track = slider.querySelector('.lbhotel-slider__track');
+        const slides = Array.from(slider.querySelectorAll('.lbhotel-slider__slide'));
+        const prevButton = slider.querySelector('.lbhotel-slider__nav--prev');
+        const nextButton = slider.querySelector('.lbhotel-slider__nav--next');
+        const dots = Array.from(slider.querySelectorAll('.lbhotel-slider__dot'));
+
+        if (!track || slides.length === 0) {
+            slider.dataset.lbhotelSliderInitialised = 'true';
+            return;
+        }
+
         let index = 0;
+        let timerId = null;
 
-        function goToSlide(newIndex) {
-            index = newIndex;
-            slidesWrapper.style.transform = `translateX(-${index * 100}%)`;
+        function updateDots() {
             dots.forEach((dot, dotIndex) => {
-                if (dotIndex === index) {
-                    dot.classList.add('is-active');
-                } else {
-                    dot.classList.remove('is-active');
-                }
+                dot.classList.toggle('is-active', dotIndex === index);
             });
         }
 
-        goToSlide(0);
-
-        if (!dots.length) {
-            return;
+        function goTo(newIndex) {
+            index = (newIndex + slides.length) % slides.length;
+            track.style.transform = `translateX(-${index * 100}%)`;
+            updateDots();
         }
 
-        function nextSlide() {
-            const nextIndex = (index + 1) % dots.length;
-            goToSlide(nextIndex);
+        function next() {
+            goTo(index + 1);
         }
 
-        dots.forEach((dot) => {
-            dot.addEventListener('click', () => {
-                const targetIndex = Number(dot.dataset.dot);
-
-                if (Number.isNaN(targetIndex)) {
-                    return;
-                }
-
-                goToSlide(targetIndex);
-            });
-        });
-
-        if (dots.length > 1) {
-            sliderIntervals.set(sliderId, window.setInterval(nextSlide, 5000));
-        }
-    }
-
-    function updatePaginationControls(total) {
-        const totalPages = total > 0 ? Math.ceil(total / state.perPage) : 1;
-
-        if (state.page > totalPages) {
-            state.page = totalPages;
+        function prev() {
+            goTo(index - 1);
         }
 
-        selectors.paginationButtons.forEach((button) => {
-            const direction = button.dataset.pagination;
-
-            if (direction === 'prev') {
-                button.disabled = state.page === 1 || total <= 0;
-            } else {
-                button.disabled = state.page >= totalPages || total <= 0;
+        function play() {
+            stop();
+            if (slides.length > 1) {
+                timerId = window.setInterval(next, 5000);
             }
-        });
-    }
-
-    function render() {
-        if (!selectors.list || !selectors.count) {
-            return;
         }
 
-        clearSliders();
-
-        const filtered = applyFilters(HOTELS);
-        const sorted = applySort(filtered);
-        const total = sorted.length;
-
-        if (total === 0) {
-            state.page = 1;
+        function stop() {
+            if (timerId) {
+                window.clearInterval(timerId);
+                timerId = null;
+            }
         }
 
-        updatePaginationControls(total);
-
-        const totalPages = total > 0 ? Math.ceil(total / state.perPage) : 1;
-
-        if (state.page > totalPages) {
-            state.page = totalPages;
-        }
-
-        const paginated = paginate(sorted);
-
-        selectors.count.textContent = String(total);
-
-        if (paginated.length === 0) {
-            const message = total === 0 ? strings.empty : strings.emptyPage;
-            selectors.list.innerHTML = `<p class="hotel-card__empty">${message}</p>`;
-            return;
-        }
-
-        selectors.list.innerHTML = paginated.map(createCard).join('');
-
-        const sliders = selectors.list.querySelectorAll('[data-slider]');
-        sliders.forEach((slider) => initSlider(slider));
-    }
-
-    function attachEvents() {
-        if (selectors.search) {
-            selectors.search.addEventListener('input', (event) => {
-                state.search = normalizeString(event.target.value);
-                state.page = 1;
-                render();
+        if (prevButton) {
+            prevButton.addEventListener('click', () => {
+                prev();
+                play();
             });
         }
 
-        if (selectors.distance) {
-            selectors.distance.addEventListener('change', (event) => {
-                state.distance = event.target.value;
-                state.page = 1;
-                render();
+        if (nextButton) {
+            nextButton.addEventListener('click', () => {
+                next();
+                play();
             });
         }
 
-        if (selectors.rating) {
-            selectors.rating.addEventListener('change', (event) => {
-                state.rating = event.target.value;
-                state.page = 1;
-                render();
-            });
-        }
-
-        if (selectors.sort) {
-            selectors.sort.addEventListener('change', (event) => {
-                state.sort = event.target.value;
-                render();
-            });
-        }
-
-        selectors.paginationButtons.forEach((button) => {
-            button.addEventListener('click', () => {
-                const direction = button.dataset.pagination;
-
-                if ('next' === direction) {
-                    state.page += 1;
-                } else {
-                    state.page -= 1;
-                }
-
-                if (state.page < 1) {
-                    state.page = 1;
-                }
-
-                render();
+        dots.forEach((dot, dotIndex) => {
+            dot.addEventListener('click', () => {
+                goTo(dotIndex);
+                play();
             });
         });
 
-        window.addEventListener('pageshow', () => {
-            render();
-        });
+        slider.addEventListener('mouseenter', stop);
+        slider.addEventListener('mouseleave', play);
+
+        slider.dataset.lbhotelSliderInitialised = 'true';
+        goTo(0);
+        play();
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', () => {
-            attachEvents();
-            render();
-        });
-    } else {
-        attachEvents();
-        render();
+    function initSliders(root) {
+        const scope = root || document;
+        const sliders = scope.querySelectorAll(sliderSelector);
+        sliders.forEach(setupSlider);
     }
+
+    function onReady(callback) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', callback, { once: true });
+        } else {
+            callback();
+        }
+    }
+
+    onReady(() => {
+        initSliders(document);
+    });
 })();

--- a/archive-lbhotel_hotel.php
+++ b/archive-lbhotel_hotel.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Modern Moroccan-inspired archive template for Le Bon Hotel listings.
+ * Archive template for the `lbhotel_hotel` custom post type.
  *
  * @package LeBonHotel
  */
@@ -9,10 +9,22 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-wp_enqueue_style( 'lbhotel-all-hotels', LBHOTEL_PLUGIN_URL . 'all-hotel.css', array(), LBHOTEL_VERSION );
-wp_enqueue_script( 'lbhotel-all-hotels', LBHOTEL_PLUGIN_URL . 'all-hotel.js', array(), LBHOTEL_VERSION, true );
+$theme_directory_uri  = get_stylesheet_directory_uri();
+$theme_directory_path = function_exists( 'get_stylesheet_directory' ) ? trailingslashit( get_stylesheet_directory() ) : '';
 
-$hotels_for_script = array();
+if ( $theme_directory_path && file_exists( $theme_directory_path . 'all-hotel.css' ) ) {
+    wp_enqueue_style( 'lbhotel-all-hotels', $theme_directory_uri . '/all-hotel.css', array(), '1.0.0' );
+} else {
+    wp_enqueue_style( 'lbhotel-all-hotels', LBHOTEL_PLUGIN_URL . 'all-hotel.css', array(), LBHOTEL_VERSION );
+}
+
+if ( $theme_directory_path && file_exists( $theme_directory_path . 'all-hotel.js' ) ) {
+    wp_enqueue_script( 'lbhotel-all-hotels', $theme_directory_uri . '/all-hotel.js', array(), '1.0.0', true );
+} else {
+    wp_enqueue_script( 'lbhotel-all-hotels', LBHOTEL_PLUGIN_URL . 'all-hotel.js', array(), LBHOTEL_VERSION, true );
+}
+
+$currency_code = function_exists( 'lbhotel_get_option' ) ? lbhotel_get_option( 'default_currency' ) : '';
 
 $hotels_query = new WP_Query(
     array(
@@ -24,96 +36,7 @@ $hotels_query = new WP_Query(
     )
 );
 
-if ( $hotels_query->have_posts() ) {
-    while ( $hotels_query->have_posts() ) {
-        $hotels_query->the_post();
-
-        $post_id = get_the_ID();
-
-        $gallery_ids  = (array) get_post_meta( $post_id, 'lbhotel_gallery_images', true );
-        $gallery_urls = array();
-
-        foreach ( $gallery_ids as $attachment_id ) {
-            $image_url = wp_get_attachment_image_url( $attachment_id, 'large' );
-
-            if ( $image_url ) {
-                $gallery_urls[] = $image_url;
-            }
-        }
-
-        if ( empty( $gallery_urls ) ) {
-            $featured_image = get_the_post_thumbnail_url( $post_id, 'large' );
-
-            if ( $featured_image ) {
-                $gallery_urls[] = $featured_image;
-            }
-        }
-
-        $latitude  = get_post_meta( $post_id, 'lbhotel_latitude', true );
-        $longitude = get_post_meta( $post_id, 'lbhotel_longitude', true );
-
-        $coordinates = null;
-
-        if ( '' !== $latitude && '' !== $longitude ) {
-            $coordinates = array(
-                'lat' => (float) $latitude,
-                'lng' => (float) $longitude,
-            );
-        }
-
-        $price_meta = get_post_meta( $post_id, 'lbhotel_avg_price_per_night', true );
-        $price      = '' !== $price_meta ? (float) $price_meta : null;
-
-        $distance_meta = get_post_meta( $post_id, 'lbhotel_distance_km', true );
-        $distance      = '' !== $distance_meta ? (float) $distance_meta : null;
-
-        $description = get_the_excerpt();
-
-        if ( ! $description ) {
-            $description = wp_trim_words( wp_strip_all_tags( get_the_content() ), 30 );
-        }
-
-        $hotels_for_script[] = array(
-            'id'             => $post_id,
-            'name'           => get_the_title(),
-            'city'           => get_post_meta( $post_id, 'lbhotel_city', true ),
-            'region'         => get_post_meta( $post_id, 'lbhotel_region', true ),
-            'country'        => get_post_meta( $post_id, 'lbhotel_country', true ),
-            'rating'         => (int) get_post_meta( $post_id, 'lbhotel_star_rating', true ),
-            'price'          => $price,
-            'distance'       => $distance,
-            'coordinates'    => $coordinates,
-            'description'    => wp_strip_all_tags( $description ),
-            'images'         => $gallery_urls,
-            'featured_image' => get_the_post_thumbnail_url( $post_id, 'large' ),
-            'booking_url'    => get_post_meta( $post_id, 'lbhotel_booking_url', true ),
-            'details_url'    => get_permalink(),
-            'available_from' => get_post_time( DATE_ATOM, true ),
-        );
-    }
-
-    wp_reset_postdata();
-}
-
-wp_localize_script(
-    'lbhotel-all-hotels',
-    'lbhotelAllHotels',
-    array(
-        'hotels'   => $hotels_for_script,
-        'currency' => lbhotel_get_option( 'default_currency' ),
-        'perPage'  => 4,
-        'strings'  => array(
-            'empty'      => __( 'No hotels match your search. Try adjusting filters.', 'lbhotel' ),
-            'emptyPage'  => __( 'No more hotels on this page.', 'lbhotel' ),
-            'reserve'    => __( 'Reserve Booking', 'lbhotel' ),
-            'map'        => __( 'Show on Map', 'lbhotel' ),
-            'details'    => __( 'View Details', 'lbhotel' ),
-            'priceLabel' => __( '/ night', 'lbhotel' ),
-            'noImage'    => __( 'Image coming soon', 'lbhotel' ),
-            'imageAlt'   => __( 'Hotel gallery image', 'lbhotel' ),
-        ),
-    )
-);
+global $post;
 
 get_header();
 ?>
@@ -122,64 +45,135 @@ get_header();
     <div class="ast-container">
         <?php if ( function_exists( 'astra_primary_content_top' ) ) { astra_primary_content_top(); } ?>
         <div id="primary" <?php if ( function_exists( 'astra_primary_class' ) ) { astra_primary_class(); } else { echo 'class="content-area"'; } ?>>
-            <main id="main" class="site-main" data-all-hotels-page>
+            <main id="main" class="site-main lbhotel-all-hotels" data-all-hotels-page role="main">
                 <?php if ( function_exists( 'astra_primary_content_before' ) ) { astra_primary_content_before(); } ?>
 
-                <div class="all-hotels" data-hotels-container>
-                    <header class="all-hotels__filters" role="banner">
-                        <form class="all-hotels__filters-form" aria-label="<?php esc_attr_e( 'Filter hotels', 'lbhotel' ); ?>">
-                            <label class="all-hotels__field" for="hotel-search">
-                                <span class="screen-reader-text"><?php esc_html_e( 'Search by hotel name or city', 'lbhotel' ); ?></span>
-                                <input type="search" id="hotel-search" name="hotel_search" placeholder="<?php esc_attr_e( 'Search hotels or cities', 'lbhotel' ); ?>" autocomplete="off" />
-                            </label>
-                            <label class="all-hotels__field" for="hotel-distance">
-                                <span class="screen-reader-text"><?php esc_html_e( 'Filter by distance', 'lbhotel' ); ?></span>
-                                <select id="hotel-distance" name="hotel_distance">
-                                    <option value="all"><?php esc_html_e( 'Any distance', 'lbhotel' ); ?></option>
-                                    <option value="5"><?php esc_html_e( 'Near me · 5 km', 'lbhotel' ); ?></option>
-                                    <option value="10"><?php esc_html_e( 'Near me · 10 km', 'lbhotel' ); ?></option>
-                                    <option value="20"><?php esc_html_e( 'Near me · 20 km', 'lbhotel' ); ?></option>
-                                </select>
-                            </label>
-                            <label class="all-hotels__field" for="hotel-rating">
-                                <span class="screen-reader-text"><?php esc_html_e( 'Filter by star rating', 'lbhotel' ); ?></span>
-                                <select id="hotel-rating" name="hotel_rating">
-                                    <option value="all"><?php esc_html_e( 'Any rating', 'lbhotel' ); ?></option>
-                                    <option value="5">5 ★</option>
-                                    <option value="4">4 ★ &amp; up</option>
-                                    <option value="3">3 ★ &amp; up</option>
-                                    <option value="2">2 ★ &amp; up</option>
-                                    <option value="1">1 ★ &amp; up</option>
-                                </select>
-                            </label>
-                        </form>
-                    </header>
+                <header class="lbhotel-archive__header">
+                    <h1 class="lbhotel-archive__title"><?php post_type_archive_title(); ?></h1>
+                    <p class="lbhotel-archive__intro"><?php esc_html_e( 'Discover authentic Moroccan stays and plan your next escape.', 'lbhotel' ); ?></p>
+                </header>
 
-                    <section class="all-hotels__sorting" role="region" aria-live="polite">
-                        <div class="all-hotels__results">
-                            <span id="hotel-count" data-hotel-count>0</span>
-                            <span class="all-hotels__results-label"><?php esc_html_e( 'hotels found', 'lbhotel' ); ?></span>
-                        </div>
-                        <label class="all-hotels__sort" for="hotel-sort">
-                            <span class="all-hotels__sort-label"><?php esc_html_e( 'Sort by', 'lbhotel' ); ?></span>
-                            <select id="hotel-sort" name="hotel_sort">
-                                <option value="date-asc"><?php esc_html_e( 'Date ASC', 'lbhotel' ); ?></option>
-                                <option value="date-desc" selected><?php esc_html_e( 'Date DESC', 'lbhotel' ); ?></option>
-                                <option value="distance-asc"><?php esc_html_e( 'Distance ASC', 'lbhotel' ); ?></option>
-                                <option value="distance-desc"><?php esc_html_e( 'Distance DESC', 'lbhotel' ); ?></option>
-                                <option value="rating-asc"><?php esc_html_e( 'Rating ASC', 'lbhotel' ); ?></option>
-                                <option value="rating-desc"><?php esc_html_e( 'Rating DESC', 'lbhotel' ); ?></option>
-                            </select>
-                        </label>
-                    </section>
+                <?php if ( $hotels_query->have_posts() ) : ?>
+                    <div class="lbhotel-archive__list">
+                        <?php
+                        while ( $hotels_query->have_posts() ) :
+                            $hotels_query->the_post();
 
-                    <section class="all-hotels__list" id="hotel-list" aria-live="polite" aria-label="<?php esc_attr_e( 'Hotel results', 'lbhotel' ); ?>"></section>
+                            $post_id = get_the_ID();
 
-                    <nav class="all-hotels__pagination" aria-label="<?php esc_attr_e( 'Hotel pagination', 'lbhotel' ); ?>">
-                        <button type="button" class="all-hotels__pagination-button" data-pagination="prev"><?php esc_html_e( 'Prev', 'lbhotel' ); ?></button>
-                        <button type="button" class="all-hotels__pagination-button" data-pagination="next"><?php esc_html_e( 'Next', 'lbhotel' ); ?></button>
-                    </nav>
-                </div>
+                            $city        = get_post_meta( $post_id, 'lbhotel_city', true );
+                            $region      = get_post_meta( $post_id, 'lbhotel_region', true );
+                            $country     = get_post_meta( $post_id, 'lbhotel_country', true );
+                            $star_rating = (int) get_post_meta( $post_id, 'lbhotel_star_rating', true );
+                            $avg_price   = get_post_meta( $post_id, 'lbhotel_avg_price_per_night', true );
+                            $booking_url = get_post_meta( $post_id, 'lbhotel_booking_url', true );
+                            $latitude    = get_post_meta( $post_id, 'lbhotel_latitude', true );
+                            $longitude   = get_post_meta( $post_id, 'lbhotel_longitude', true );
+
+                            $gallery_raw = get_post_meta( $post_id, 'lbhotel_gallery_images', true );
+                            $gallery_ids = is_array( $gallery_raw ) ? $gallery_raw : array_filter( array_map( 'absint', (array) $gallery_raw ) );
+
+                            $gallery_urls = array();
+                            foreach ( $gallery_ids as $attachment_id ) {
+                                $image_url = wp_get_attachment_image_url( $attachment_id, 'large' );
+                                if ( $image_url ) {
+                                    $gallery_urls[] = $image_url;
+                                }
+                            }
+
+                            if ( empty( $gallery_urls ) ) {
+                                $featured_image = get_the_post_thumbnail_url( $post_id, 'large' );
+                                if ( $featured_image ) {
+                                    $gallery_urls[] = $featured_image;
+                                }
+                            }
+
+                            $gallery_urls = array_slice( $gallery_urls, 0, 5 );
+
+                            $price_display = '';
+                            if ( '' !== $avg_price && null !== $avg_price ) {
+                                $price_display = is_numeric( $avg_price ) ? number_format_i18n( (float) $avg_price, 2 ) : sanitize_text_field( $avg_price );
+                            }
+
+                            $price_text = $price_display;
+                            if ( $price_display && $currency_code ) {
+                                $price_text = sprintf( '%s %s', $currency_code, $price_display );
+                            }
+
+                            $map_url = '';
+                            if ( is_numeric( $latitude ) && is_numeric( $longitude ) ) {
+                                $map_url = sprintf( 'https://www.google.com/maps/search/?api=1&query=%s', rawurlencode( $latitude . ',' . $longitude ) );
+                            }
+
+                            $location_parts = array_filter( array( $city, $region, $country ) );
+                            ?>
+
+                            <article id="post-<?php the_ID(); ?>" <?php post_class( 'lbhotel-archive-card' ); ?>>
+                                <div class="lbhotel-archive-card__media">
+                                    <?php if ( $gallery_urls ) : ?>
+                                        <div class="lbhotel-slider" data-lbhotel-slider>
+                                            <div class="lbhotel-slider__track">
+                                                <?php foreach ( $gallery_urls as $image_url ) : ?>
+                                                    <div class="lbhotel-slider__slide">
+                                                        <img src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( get_the_title() ); ?>" loading="lazy" />
+                                                    </div>
+                                                <?php endforeach; ?>
+                                            </div>
+                                            <?php if ( count( $gallery_urls ) > 1 ) : ?>
+                                                <button type="button" class="lbhotel-slider__nav lbhotel-slider__nav--prev" aria-label="<?php esc_attr_e( 'Previous image', 'lbhotel' ); ?>">&#10094;</button>
+                                                <button type="button" class="lbhotel-slider__nav lbhotel-slider__nav--next" aria-label="<?php esc_attr_e( 'Next image', 'lbhotel' ); ?>">&#10095;</button>
+                                                <div class="lbhotel-slider__dots" role="tablist">
+                                                    <?php foreach ( $gallery_urls as $index => $unused ) : ?>
+                                                        <button type="button" class="lbhotel-slider__dot" aria-label="<?php echo esc_attr( sprintf( __( 'Go to image %d', 'lbhotel' ), $index + 1 ) ); ?>"></button>
+                                                    <?php endforeach; ?>
+                                                </div>
+                                            <?php endif; ?>
+                                        </div>
+                                    <?php else : ?>
+                                        <div class="lbhotel-slider lbhotel-slider--empty">
+                                            <span><?php esc_html_e( 'No images available', 'lbhotel' ); ?></span>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+
+                                <div class="lbhotel-archive-card__content">
+                                    <h2 class="lbhotel-archive-card__title">
+                                        <a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+                                    </h2>
+                                    <?php if ( $location_parts ) : ?>
+                                        <p class="lbhotel-archive-card__location"><?php echo esc_html( implode( ', ', $location_parts ) ); ?></p>
+                                    <?php endif; ?>
+
+                                    <?php if ( $star_rating > 0 ) : ?>
+                                        <div class="lbhotel-archive-card__stars" aria-label="<?php echo esc_attr( sprintf( _n( '%d star', '%d stars', $star_rating, 'lbhotel' ), $star_rating ) ); ?>">
+                                            <?php echo wp_kses_post( str_repeat( '<span aria-hidden="true">★</span>', min( 5, $star_rating ) ) ); ?>
+                                        </div>
+                                    <?php endif; ?>
+
+                                    <?php if ( $price_text ) : ?>
+                                        <p class="lbhotel-archive-card__price"><?php echo esc_html( sprintf( __( 'Average price per night: %s', 'lbhotel' ), $price_text ) ); ?></p>
+                                    <?php endif; ?>
+                                </div>
+
+                                <div class="lbhotel-archive-card__actions">
+                                    <?php if ( $booking_url ) : ?>
+                                        <a class="lbhotel-button lbhotel-button--reserve" href="<?php echo esc_url( $booking_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Reserve Booking', 'lbhotel' ); ?></a>
+                                    <?php endif; ?>
+
+                                    <?php if ( $map_url ) : ?>
+                                        <a class="lbhotel-button lbhotel-button--map" href="<?php echo esc_url( $map_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Google Map', 'lbhotel' ); ?></a>
+                                    <?php endif; ?>
+
+                                    <a class="lbhotel-button lbhotel-button--details" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View Details', 'lbhotel' ); ?></a>
+                                </div>
+                            </article>
+                        <?php endwhile; ?>
+                    </div>
+                <?php else : ?>
+                    <p class="lbhotel-archive__empty"><?php esc_html_e( 'No hotels found at this time. Please check back soon.', 'lbhotel' ); ?></p>
+                <?php endif; ?>
+
+                <?php wp_reset_postdata(); ?>
 
                 <?php if ( function_exists( 'astra_primary_content_after' ) ) { astra_primary_content_after(); } ?>
             </main>


### PR DESCRIPTION
## Summary
- replace the archive template with a real `WP_Query` loop that renders each `lbhotel_hotel` card using gallery images, meta details, and action buttons
- restyle the archive layout with Moroccan-inspired full-width cards and responsive spacing aligned with the single hotel design
- initialize the archive sliders with lightweight JavaScript so each card cycles through its gallery images

## Testing
- php -l archive-lbhotel_hotel.php

------
https://chatgpt.com/codex/tasks/task_e_68df2a7567d88324aea978b07212e9b2