### PR TITLE
Add virtual tour and map overlays to hotel cards

### DIFF
--- a/all-hotel.css
+++ b/all-hotel.css
@@ -452,6 +452,36 @@ body.archive.post-type-archive-lbhotel_hotel {
     display: flex;
     align-items: stretch;
     justify-content: center;
+    position: relative;
+}
+
+.lbhotel-info-card__icons {
+    position: absolute;
+    top: 0.8rem;
+    right: 0.8rem;
+    display: flex;
+    gap: 0.5rem;
+    z-index: 10;
+}
+
+.lbhotel-icon {
+    background: rgba(255, 255, 255, 0.9);
+    border: none;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    font-size: 18px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lbhotel-icon:hover,
+.lbhotel-icon:focus-visible {
+    background: #C1272D;
+    color: #fff;
 }
 
 .lbhotel-info-card__details {
@@ -795,3 +825,63 @@ body.archive.post-type-archive-lbhotel_hotel {
         height: 2.1rem;
         font-size: 1.05rem;
     }
+
+.lbhotel-popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    padding: 1rem;
+}
+
+.lbhotel-popup-content {
+    width: 90%;
+    height: 90%;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.lbhotel-popup-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: #C1272D;
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    font-size: 1.2rem;
+    width: 35px;
+    height: 35px;
+    cursor: pointer;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lbhotel-popup-body {
+    width: 100%;
+    height: 100%;
+    flex: 1 1 auto;
+}
+
+.lbhotel-popup-body iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.lbhotel-popup-map {
+    width: 100%;
+    height: 100%;
+}

--- a/all-hotel.js
+++ b/all-hotel.js
@@ -6,6 +6,42 @@ if (typeof window !== 'undefined') {
 (function () {
     const sliderSelector = '[data-lbhotel-slider]';
 
+    const escapeHtml = (value) => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    };
+
+    const normaliseHotel = (hotel) => {
+        if (!hotel) {
+            return null;
+        }
+
+        const lat = Number(hotel.lat);
+        const lng = Number(hotel.lng);
+
+        return {
+            id: hotel.id || `hotel-${Math.random().toString(16).slice(2)}`,
+            name: hotel.title || hotel.name || 'Hotel',
+            city: hotel.city || '',
+            price: hotel.price || '',
+            stars: Number(hotel.stars) || 0,
+            bookingUrl: hotel.bookingUrl || hotel.booking_url || '',
+            mapUrl: hotel.mapUrl || hotel.map_url || '',
+            permalink: hotel.permalink || hotel.detailsUrl || '#',
+            lat: Number.isFinite(lat) ? lat : null,
+            lng: Number.isFinite(lng) ? lng : null,
+            images: Array.isArray(hotel.images) ? hotel.images.slice(0, 5) : [],
+            virtualTourUrl: hotel.virtualTourUrl || hotel.virtual_tour_url || hotel.tourUrl || '',
+        };
+    };
+
     function setupSlider(slider) {
         if (!slider || slider.dataset.lbhotelSliderInitialised) {
             return;
@@ -134,8 +170,382 @@ if (typeof window !== 'undefined') {
         });
     }
 
+    const buildPopupSlider = (hotel) => {
+        if (!hotel.images || hotel.images.length === 0) {
+            return '';
+        }
+
+        const slides = hotel.images
+            .map(
+                (url) => `
+            <div class="lbhotel-slider__slide">
+                <img src="${escapeHtml(url)}" alt="${escapeHtml(hotel.name)}" />
+            </div>`
+            )
+            .join('');
+
+        const dots = hotel.images
+            .map(
+                (_, index) => `
+            <div class="lbhotel-slider__dot" aria-label="Image ${index + 1}" role="button" tabindex="0"></div>`
+            )
+            .join('');
+
+        return `
+        <div class="lbhotel-slider" data-lbhotel-slider>
+            <div class="lbhotel-slider__track">
+                ${slides}
+            </div>
+            <div class="lbhotel-slider__nav lbhotel-slider__nav--prev" aria-label="Previous image" role="button" tabindex="0">&#10094;</div>
+            <div class="lbhotel-slider__nav lbhotel-slider__nav--next" aria-label="Next image" role="button" tabindex="0">&#10095;</div>
+            <div class="lbhotel-slider__dots">
+                ${dots}
+            </div>
+        </div>`;
+    };
+
+    const buildPopup = (hotel) => {
+        const numericStars = Math.max(0, Math.min(5, Number(hotel.stars) || 0));
+        const stars = numericStars > 0 ? '★'.repeat(numericStars) : '';
+        const slider = buildPopupSlider(hotel);
+        const metaParts = [hotel.city, hotel.price].filter(Boolean).join(' · ');
+
+        const buttons = [
+            hotel.bookingUrl
+                ? `<a class="lbhotel-button lbhotel-button--reserve" href="${escapeHtml(hotel.bookingUrl)}" target="_blank" rel="noopener noreferrer">Reserve Booking</a>`
+                : '',
+            hotel.mapUrl
+                ? `<a class="lbhotel-button lbhotel-button--map" href="${escapeHtml(hotel.mapUrl)}" target="_blank" rel="noopener noreferrer">Show in Google Map</a>`
+                : '',
+            `<a class="lbhotel-button lbhotel-button--details" href="${escapeHtml(hotel.permalink)}">View Details</a>`,
+        ]
+            .filter(Boolean)
+            .join('');
+
+        return `
+        <div class="lbhotel-popup">
+            <h3>${escapeHtml(hotel.name)}</h3>
+            ${slider}
+            ${metaParts ? `<p class="lbhotel-popup__meta">${escapeHtml(metaParts)}</p>` : ''}
+            ${stars ? `<div class="lbhotel-popup__stars">${escapeHtml(stars)} <span class="lbhotel-popup__stars-text">${numericStars}/5</span></div>` : ''}
+            <div class="lbhotel-popup__actions">${buttons}</div>
+        </div>`;
+    };
+
+    const parseHotelFromCard = (card) => {
+        if (!card || !card.dataset || !card.dataset.hotel) {
+            return null;
+        }
+
+        try {
+            const parsed = JSON.parse(card.dataset.hotel);
+            return normaliseHotel(parsed);
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const collectHotelsData = (selectedHotel = null) => {
+        const data = window.lbHotelArchiveData || {};
+        const fallback = data.fallbackCenter || { lat: 31.7917, lng: -7.0926 };
+        const hotelsMap = new Map();
+
+        const addHotel = (hotel) => {
+            if (!hotel) {
+                return;
+            }
+
+            const key = String(hotel.id || hotel.permalink || hotel.name || Math.random().toString(16).slice(2));
+            if (hotelsMap.has(key)) {
+                Object.assign(hotelsMap.get(key), hotel);
+            } else {
+                hotelsMap.set(key, hotel);
+            }
+        };
+
+        if (Array.isArray(data.hotels)) {
+            data.hotels.map(normaliseHotel).forEach(addHotel);
+        }
+
+        const cards = document.querySelectorAll('.lbhotel-info-card[data-hotel]');
+        cards.forEach((card) => {
+            const parsed = parseHotelFromCard(card);
+            if (parsed) {
+                addHotel(parsed);
+            }
+        });
+
+        let current = null;
+
+        if (selectedHotel) {
+            const selectedNormalised = normaliseHotel(selectedHotel);
+            if (selectedNormalised) {
+                const key = String(selectedNormalised.id || selectedNormalised.permalink || selectedNormalised.name);
+                addHotel(selectedNormalised);
+                current = hotelsMap.get(key) || selectedNormalised;
+            }
+        }
+
+        if (!current) {
+            const iterator = hotelsMap.values().next();
+            if (!iterator.done) {
+                current = iterator.value;
+            }
+        }
+
+        return {
+            hotels: Array.from(hotelsMap.values()),
+            current,
+            fallbackCenter: fallback,
+        };
+    };
+
+    const createBaseMap = (element, fallbackCenter, options = {}) => {
+        if (!element || typeof L === 'undefined') {
+            return null;
+        }
+
+        const lat = Number(fallbackCenter && fallbackCenter.lat);
+        const lng = Number(fallbackCenter && fallbackCenter.lng);
+        const defaultCenter = Number.isFinite(lat) && Number.isFinite(lng) ? [lat, lng] : [31.7917, -7.0926];
+
+        const baseLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
+        });
+
+        const satelliteLayer = L.tileLayer(
+            'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            {
+                attribution:
+                    'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+                maxZoom: 19,
+            }
+        );
+
+        const map = L.map(
+            element,
+            Object.assign(
+                {
+                    center: defaultCenter,
+                    zoom: 6,
+                    layers: [baseLayer],
+                    scrollWheelZoom: false,
+                },
+                options
+            )
+        );
+
+        const layersControl = L.control.layers(
+            {
+                Map: baseLayer,
+                Satellite: satelliteLayer,
+            },
+            null,
+            { position: 'topright' }
+        ).addTo(map);
+
+        if (layersControl && layersControl._container) {
+            layersControl._container.classList.add('leaflet-control-layers-expanded');
+        }
+
+        return { map, layersControl };
+    };
+
+    const renderHotelsOnMap = (map, hotels) => {
+        if (!map || typeof L === 'undefined') {
+            return { markerById: {}, bounds: [] };
+        }
+
+        const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="150" zoomAndPan="magnify" viewBox="0 0 112.5 149.999998" height="200" preserveAspectRatio="xMidYMid meet"><defs><filter id="shadow" x="-0.0869574" y="-0.0869565" width="1.17391" height="1.17391"><feGaussianBlur stdDeviation="1.449"/></filter><linearGradient x1="0" y1="0.498047" x2="1" y2="0.498047" id="gradient"><stop offset="0" stop-color="#8d0e15"/><stop offset="1" stop-color="#c1272d"/></linearGradient></defs><path d="M 56.25 0 C 25.214844 0 0 25.214844 0 56.25 C 0 69.492188 4.367188 82.363281 12.285156 92.855469 L 52.382812 145.523438 C 52.703125 145.945312 53.175781 146.210938 53.699219 146.25 C 53.730469 146.25 53.769531 146.25 53.808594 146.25 C 54.292969 146.25 54.753906 146.066406 55.109375 145.734375 C 55.222656 145.625 55.308594 145.5 55.394531 145.394531 L 100.214844 85.894531 C 108.085938 75.515625 112.5 62.621094 112.5 49.394531 C 112.5 22.128906 86.917969 0 56.25 0 Z" fill="url(#gradient)"/><path d="M 56.25 0 C 25.214844 0 0 25.214844 0 56.25 C 0 69.492188 4.367188 82.363281 12.285156 92.855469 L 52.382812 145.523438 C 52.703125 145.945312 53.175781 146.210938 53.699219 146.25 C 53.730469 146.25 53.769531 146.25 53.808594 146.25 C 54.292969 146.25 54.753906 146.066406 55.109375 145.734375 C 55.222656 145.625 55.308594 145.5 55.394531 145.394531 L 100.214844 85.894531 C 108.085938 75.515625 112.5 62.621094 112.5 49.394531 C 112.5 22.128906 86.917969 0 56.25 0 Z" fill="#000" fill-opacity="0.15" filter="url(#shadow)"/><path d="M 56.25 9.375 C 30.210938 9.375 9.375 30.210938 9.375 56.25 C 9.375 68.191406 13.289062 79.847656 20.753906 89.5 L 56.113281 136.214844 L 90.449219 91.425781 C 97.871094 81.566406 101.796875 69.855469 101.796875 57.875 C 101.796875 30.195312 81.089844 9.375 56.25 9.375 Z" fill="#fff"/><path d="M 56.25 23.4375 C 38.101562 23.4375 23.4375 38.101562 23.4375 56.25 C 23.4375 74.398438 38.101562 89.0625 56.25 89.0625 C 74.398438 89.0625 89.0625 74.398438 89.0625 56.25 C 89.0625 38.101562 74.398438 23.4375 56.25 23.4375 Z" fill="#f7f7f7"/><path d="M 56.25 33.75 C 43.347656 33.75 32.8125 44.285156 32.8125 57.1875 C 32.8125 70.089844 43.347656 80.625 56.25 80.625 C 69.152344 80.625 79.6875 70.089844 79.6875 57.1875 C 79.6875 44.285156 69.152344 33.75 56.25 33.75 Z" fill="#c1272d"/></svg>`;
+        const pinUrl = 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(pinSvg);
+        const hotelIcon = L.icon({
+            iconUrl: pinUrl,
+            iconSize: [30, 40],
+            iconAnchor: [15, 40],
+            popupAnchor: [0, -40],
+            className: 'lbhotel-marker-icon',
+        });
+
+        const markerById = {};
+        const bounds = [];
+
+        (hotels || [])
+            .filter((hotel) => hotel && Number.isFinite(hotel.lat) && Number.isFinite(hotel.lng))
+            .forEach((hotel) => {
+                const marker = L.marker([hotel.lat, hotel.lng], { icon: hotelIcon }).addTo(map);
+                marker.bindPopup(buildPopup(hotel));
+                bounds.push([hotel.lat, hotel.lng]);
+                markerById[String(hotel.id)] = marker;
+            });
+
+        if (bounds.length > 1) {
+            map.fitBounds(bounds, { padding: [40, 40] });
+        } else if (bounds.length === 1) {
+            map.setView(bounds[0], 13);
+        }
+
+        map.on('popupopen', (event) => {
+            const popupRoot = event.popup.getElement();
+            if (popupRoot) {
+                initSliders(popupRoot);
+            }
+        });
+
+        return { markerById, bounds };
+    };
+
+    const focusOnHotel = (map, current, markerById, fallbackCenter) => {
+        if (!map) {
+            return;
+        }
+
+        const fallbackLat = Number(fallbackCenter && fallbackCenter.lat);
+        const fallbackLng = Number(fallbackCenter && fallbackCenter.lng);
+
+        window.setTimeout(() => {
+            map.invalidateSize();
+
+            if (current && Number.isFinite(current.lat) && Number.isFinite(current.lng)) {
+                map.setView([current.lat, current.lng], 15);
+                const target = markerById[String(current.id)];
+                if (target) {
+                    target.openPopup();
+                }
+                return;
+            }
+
+            if (Number.isFinite(fallbackLat) && Number.isFinite(fallbackLng)) {
+                map.setView([fallbackLat, fallbackLng], 6);
+            }
+        }, 250);
+    };
+
+    const createOverlay = () => {
+        const overlay = document.createElement('div');
+        overlay.className = 'lbhotel-popup-overlay';
+
+        const content = document.createElement('div');
+        content.className = 'lbhotel-popup-content';
+
+        const closeButton = document.createElement('button');
+        closeButton.type = 'button';
+        closeButton.className = 'lbhotel-popup-close';
+        closeButton.setAttribute('aria-label', 'Close popup');
+        closeButton.textContent = '✕';
+
+        const body = document.createElement('div');
+        body.className = 'lbhotel-popup-body';
+
+        content.appendChild(closeButton);
+        content.appendChild(body);
+        overlay.appendChild(content);
+        document.body.appendChild(overlay);
+
+        const destroy = () => {
+            document.removeEventListener('keydown', onKeyDown);
+            if (overlay.parentNode) {
+                overlay.parentNode.removeChild(overlay);
+            }
+        };
+
+        const onKeyDown = (event) => {
+            if (event.key === 'Escape' || event.key === 'Esc') {
+                destroy();
+            }
+        };
+
+        closeButton.addEventListener('click', destroy);
+        overlay.addEventListener('click', (event) => {
+            if (event.target === overlay) {
+                destroy();
+            }
+        });
+        document.addEventListener('keydown', onKeyDown);
+
+        return { overlay, content, body, destroy };
+    };
+
+    const openVirtualTourOverlay = (url, hotelName) => {
+        if (!url) {
+            return;
+        }
+
+        const overlay = createOverlay();
+        if (!overlay) {
+            return;
+        }
+
+        const iframe = document.createElement('iframe');
+        iframe.src = url;
+        iframe.title = hotelName ? `${hotelName} – Virtual Tour` : 'Virtual Tour';
+        iframe.loading = 'lazy';
+        iframe.allowFullscreen = true;
+        overlay.body.appendChild(iframe);
+    };
+
+    const openMapOverlay = (hotels, current, fallbackCenter) => {
+        const overlay = createOverlay();
+        if (!overlay) {
+            return;
+        }
+
+        if (typeof L === 'undefined') {
+            const message = document.createElement('p');
+            message.textContent = 'Map view is currently unavailable.';
+            message.style.padding = '2rem';
+            overlay.body.appendChild(message);
+            return;
+        }
+
+        const mapContainer = document.createElement('div');
+        mapContainer.className = 'lbhotel-popup-map';
+        overlay.body.appendChild(mapContainer);
+
+        window.setTimeout(() => {
+            const base = createBaseMap(mapContainer, fallbackCenter, { scrollWheelZoom: true });
+            if (!base) {
+                return;
+            }
+
+            const { markerById } = renderHotelsOnMap(base.map, hotels);
+            focusOnHotel(base.map, current, markerById, fallbackCenter);
+        }, 0);
+    };
+
+    const attachInfoCardHandlers = () => {
+        const cards = document.querySelectorAll('.lbhotel-info-card');
+        cards.forEach((card) => {
+            if (card.dataset.lbhotelIconsInitialised) {
+                return;
+            }
+
+            card.dataset.lbhotelIconsInitialised = 'true';
+
+            const hotelData = parseHotelFromCard(card);
+
+            const tourButton = card.querySelector('.lbhotel-icon--tour');
+            if (tourButton) {
+                tourButton.addEventListener('click', () => {
+                    const url = tourButton.dataset.tourUrl || (hotelData ? hotelData.virtualTourUrl : '');
+                    if (url) {
+                        openVirtualTourOverlay(url, hotelData ? hotelData.name : document.title);
+                    }
+                });
+            }
+
+            const mapButton = card.querySelector('.lbhotel-icon--map');
+            if (mapButton) {
+                mapButton.addEventListener('click', () => {
+                    const { hotels, current, fallbackCenter } = collectHotelsData(hotelData);
+                    openMapOverlay(hotels, current, fallbackCenter);
+                });
+            }
+        });
+    };
+
     onReady(() => {
         initSliders(document);
         initPerPageSelector();
+        attachInfoCardHandlers();
     });
 })();

--- a/archive-lbhotel_hotel.php
+++ b/archive-lbhotel_hotel.php
@@ -17,6 +17,8 @@ $theme_script_path    = $theme_directory_path ? $theme_directory_path . 'all-hot
 $plugin_style_path  = trailingslashit( LBHOTEL_PLUGIN_DIR ) . 'all-hotel.css';
 $plugin_script_path = trailingslashit( LBHOTEL_PLUGIN_DIR ) . 'all-hotel.js';
 
+wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', array(), '1.9.4' );
+
 if ( $theme_style_path && file_exists( $theme_style_path ) ) {
     $style_version = (string) ( filemtime( $theme_style_path ) ?: time() );
     wp_enqueue_style( 'lbhotel-all-hotels', $theme_directory_uri . '/all-hotel.css', array(), $style_version );
@@ -25,12 +27,14 @@ if ( $theme_style_path && file_exists( $theme_style_path ) ) {
     wp_enqueue_style( 'lbhotel-all-hotels', LBHOTEL_PLUGIN_URL . 'all-hotel.css', array(), $style_version );
 }
 
+wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), '1.9.4', true );
+
 if ( $theme_script_path && file_exists( $theme_script_path ) ) {
     $script_version = (string) ( filemtime( $theme_script_path ) ?: time() );
-    wp_enqueue_script( 'lbhotel-all-hotels', $theme_directory_uri . '/all-hotel.js', array(), $script_version, true );
+    wp_enqueue_script( 'lbhotel-all-hotels', $theme_directory_uri . '/all-hotel.js', array( 'leaflet' ), $script_version, true );
 } else {
     $script_version = file_exists( $plugin_script_path ) ? (string) filemtime( $plugin_script_path ) : LBHOTEL_VERSION;
-    wp_enqueue_script( 'lbhotel-all-hotels', LBHOTEL_PLUGIN_URL . 'all-hotel.js', array(), $script_version, true );
+    wp_enqueue_script( 'lbhotel-all-hotels', LBHOTEL_PLUGIN_URL . 'all-hotel.js', array( 'leaflet' ), $script_version, true );
 }
 
 $currency_code = function_exists( 'lbhotel_get_option' ) ? lbhotel_get_option( 'default_currency' ) : '';
@@ -54,6 +58,8 @@ $hotels_query = new WP_Query(
 );
 
 global $post;
+
+$hotels_payload = array();
 
 get_header();
 ?>
@@ -137,6 +143,11 @@ get_header();
                                 $latitude    = get_post_meta( $post_id, 'lbhotel_latitude', true );
                                 $longitude   = get_post_meta( $post_id, 'lbhotel_longitude', true );
 
+                                $virtual_tour_url = get_post_meta( $post_id, 'virtual_tour_url', true );
+                                if ( ! $virtual_tour_url ) {
+                                    $virtual_tour_url = get_post_meta( $post_id, 'lbhotel_virtual_tour_url', true );
+                                }
+
                                 $gallery_raw = get_post_meta( $post_id, 'lbhotel_gallery_images', true );
                                 $gallery_ids = is_array( $gallery_raw ) ? $gallery_raw : array_filter( array_map( 'absint', (array) $gallery_raw ) );
 
@@ -173,10 +184,34 @@ get_header();
                                 }
 
                                 $location_parts = array_filter( array( $city, $region, $country ) );
+
+                                $hotel_payload = array(
+                                    'id'             => $post_id,
+                                    'title'          => get_the_title(),
+                                    'lat'            => is_numeric( $latitude ) ? (float) $latitude : null,
+                                    'lng'            => is_numeric( $longitude ) ? (float) $longitude : null,
+                                    'city'           => $city,
+                                    'region'         => $region,
+                                    'country'        => $country,
+                                    'price'          => $price_text,
+                                    'stars'          => $star_rating,
+                                    'bookingUrl'     => $booking_url ? esc_url_raw( $booking_url ) : '',
+                                    'mapUrl'         => $map_url ? esc_url_raw( $map_url ) : '',
+                                    'permalink'      => get_permalink(),
+                                    'images'         => $gallery_urls,
+                                    'virtualTourUrl' => $virtual_tour_url ? esc_url_raw( $virtual_tour_url ) : '',
+                                );
+
+                                $hotels_payload[] = $hotel_payload;
                                 ?>
 
-                                <section class="lbhotel-info-card" aria-labelledby="hotel-<?php the_ID(); ?>-title">
+                                <section class="lbhotel-info-card" aria-labelledby="hotel-<?php the_ID(); ?>-title"
+                                    data-hotel='<?php echo esc_attr( wp_json_encode( $hotel_payload ) ); ?>'>
                                     <div class="lbhotel-info-card__media">
+                                        <div class="lbhotel-info-card__icons">
+                                            <button type="button" class="lbhotel-icon lbhotel-icon--tour" aria-label="<?php esc_attr_e( 'Virtual Tour', 'lbhotel' ); ?>" data-tour-url="<?php echo esc_url( $virtual_tour_url ); ?>">🎥</button>
+                                            <button type="button" class="lbhotel-icon lbhotel-icon--map" aria-label="<?php esc_attr_e( 'Map View', 'lbhotel' ); ?>">🗺️</button>
+                                        </div>
                                         <?php if ( $gallery_urls ) : ?>
                                             <div class="lbhotel-slider" data-lbhotel-slider>
                                                 <div class="lbhotel-slider__track">
@@ -242,7 +277,23 @@ get_header();
                     <?php endif; ?>
                 </div>
 
-                <?php wp_reset_postdata(); ?>
+                <?php
+                wp_reset_postdata();
+
+                if ( ! empty( $hotels_payload ) ) {
+                    wp_localize_script(
+                        'lbhotel-all-hotels',
+                        'lbHotelArchiveData',
+                        array(
+                            'hotels'          => array_values( $hotels_payload ),
+                            'fallbackCenter'  => array(
+                                'lat' => 31.7917,
+                                'lng' => -7.0926,
+                            ),
+                        )
+                    );
+                }
+                ?>
 
                 <?php
                 $pagination_add_args = array();

--- a/single-hotel.css
+++ b/single-hotel.css
@@ -132,6 +132,36 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
+}
+
+.lbhotel-info-card__icons {
+    position: absolute;
+    top: 0.8rem;
+    right: 0.8rem;
+    display: flex;
+    gap: 0.5rem;
+    z-index: 10;
+}
+
+.lbhotel-icon {
+    background: rgba(255, 255, 255, 0.9);
+    border: none;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    font-size: 18px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lbhotel-icon:hover,
+.lbhotel-icon:focus-visible {
+    background: #C1272D;
+    color: #fff;
 }
 
 .lbhotel-slider {
@@ -640,4 +670,63 @@ html, body {
     max-width: 100% !important;
     width: 100% !important;
     margin: 0% !important;
+}
+.lbhotel-popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+    padding: 1rem;
+}
+
+.lbhotel-popup-content {
+    width: 90%;
+    height: 90%;
+    background: #fff;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.lbhotel-popup-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: #C1272D;
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    font-size: 1.2rem;
+    width: 35px;
+    height: 35px;
+    cursor: pointer;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lbhotel-popup-body {
+    width: 100%;
+    height: 100%;
+    flex: 1 1 auto;
+}
+
+.lbhotel-popup-body iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.lbhotel-popup-map {
+    width: 100%;
+    height: 100%;
 }

--- a/single-hotel.js
+++ b/single-hotel.js
@@ -31,6 +31,7 @@
             lat: Number.isFinite(lat) ? lat : null,
             lng: Number.isFinite(lng) ? lng : null,
             images: Array.isArray(hotel.images) ? hotel.images.slice(0, 5) : [],
+            virtualTourUrl: hotel.virtualTourUrl || hotel.virtual_tour_url || hotel.tourUrl || '',
         };
     };
 
@@ -159,6 +160,79 @@
         });
     };
 
+    const parseHotelFromCard = (card) => {
+        if (!card || !card.dataset || !card.dataset.hotel) {
+            return null;
+        }
+
+        try {
+            const parsed = JSON.parse(card.dataset.hotel);
+            return normaliseHotel(parsed);
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const collectHotelsData = (selectedHotel = null) => {
+        const data = window.lbHotelSingleData || {};
+        const fallback = data.fallbackCenter || { lat: 31.7917, lng: -7.0926 };
+        const hotelsMap = new Map();
+
+        const addHotel = (hotel) => {
+            if (!hotel) {
+                return;
+            }
+
+            const key = String(hotel.id || hotel.permalink || hotel.name || Math.random().toString(16).slice(2));
+            if (hotelsMap.has(key)) {
+                Object.assign(hotelsMap.get(key), hotel);
+            } else {
+                hotelsMap.set(key, hotel);
+            }
+        };
+
+        const currentFromData = normaliseHotel(data.currentHotel);
+        if (currentFromData) {
+            addHotel(currentFromData);
+        }
+
+        if (Array.isArray(data.otherHotels)) {
+            data.otherHotels.map(normaliseHotel).forEach(addHotel);
+        }
+
+        const cards = document.querySelectorAll('.lbhotel-info-card[data-hotel]');
+        cards.forEach((card) => {
+            const parsed = parseHotelFromCard(card);
+            if (parsed) {
+                addHotel(parsed);
+            }
+        });
+
+        let current = currentFromData;
+
+        if (selectedHotel) {
+            const selectedNormalised = normaliseHotel(selectedHotel);
+            if (selectedNormalised) {
+                const key = String(selectedNormalised.id || selectedNormalised.permalink || selectedNormalised.name);
+                addHotel(selectedNormalised);
+                current = hotelsMap.get(key) || selectedNormalised;
+            }
+        }
+
+        if (!current) {
+            const iterator = hotelsMap.values().next();
+            if (!iterator.done) {
+                current = iterator.value;
+            }
+        }
+
+        return {
+            hotels: Array.from(hotelsMap.values()),
+            current,
+            fallbackCenter: fallback,
+        };
+    };
+
     const buildPopupSlider = (hotel) => {
         if (!hotel.images || hotel.images.length === 0) {
             return '';
@@ -219,6 +293,248 @@
             ${stars ? `<div class="lbhotel-popup__stars">${escapeHtml(stars)} <span class="lbhotel-popup__stars-text">${numericStars}/5</span></div>` : ''}
             <div class="lbhotel-popup__actions">${buttons}</div>
         </div>`;
+    };
+
+    const createBaseMap = (element, fallbackCenter, options = {}) => {
+        if (!element || typeof L === 'undefined') {
+            return null;
+        }
+
+        const lat = Number(fallbackCenter && fallbackCenter.lat);
+        const lng = Number(fallbackCenter && fallbackCenter.lng);
+        const defaultCenter = Number.isFinite(lat) && Number.isFinite(lng) ? [lat, lng] : [31.7917, -7.0926];
+
+        const baseLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
+        });
+
+        const satelliteLayer = L.tileLayer(
+            'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            {
+                attribution:
+                    'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+                maxZoom: 19,
+            }
+        );
+
+        const map = L.map(
+            element,
+            Object.assign(
+                {
+                    center: defaultCenter,
+                    zoom: 6,
+                    layers: [baseLayer],
+                    scrollWheelZoom: false,
+                },
+                options
+            )
+        );
+
+        const layersControl = L.control.layers(
+            {
+                Map: baseLayer,
+                Satellite: satelliteLayer,
+            },
+            null,
+            { position: 'topright' }
+        ).addTo(map);
+
+        if (layersControl && layersControl._container) {
+            layersControl._container.classList.add('leaflet-control-layers-expanded');
+        }
+
+        return { map, layersControl };
+    };
+
+    const renderHotelsOnMap = (map, hotels) => {
+        if (!map || typeof L === 'undefined') {
+            return { markerById: {}, bounds: [] };
+        }
+
+        const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="150" zoomAndPan="magnify" viewBox="0 0 112.5 149.999998" height="200" preserveAspectRatio="xMidYMid meet"><defs><filter id="shadow" x="-0.0869574" y="-0.0869565" width="1.17391" height="1.17391"><feGaussianBlur stdDeviation="1.449"/></filter><linearGradient x1="0" y1="0.498047" x2="1" y2="0.498047" id="gradient"><stop offset="0" stop-color="#8d0e15"/><stop offset="1" stop-color="#c1272d"/></linearGradient></defs><path d="M 56.25 0 C 25.214844 0 0 25.214844 0 56.25 C 0 69.492188 4.367188 82.363281 12.285156 92.855469 L 52.382812 145.523438 C 52.703125 145.945312 53.175781 146.210938 53.699219 146.25 C 53.730469 146.25 53.769531 146.25 53.808594 146.25 C 54.292969 146.25 54.753906 146.066406 55.109375 145.734375 C 55.222656 145.625 55.308594 145.5 55.394531 145.394531 L 100.214844 85.894531 C 108.085938 75.515625 112.5 62.621094 112.5 49.394531 C 112.5 22.128906 86.917969 0 56.25 0 Z" fill="url(#gradient)"/><path d="M 56.25 0 C 25.214844 0 0 25.214844 0 56.25 C 0 69.492188 4.367188 82.363281 12.285156 92.855469 L 52.382812 145.523438 C 52.703125 145.945312 53.175781 146.210938 53.699219 146.25 C 53.730469 146.25 53.769531 146.25 53.808594 146.25 C 54.292969 146.25 54.753906 146.066406 55.109375 145.734375 C 55.222656 145.625 55.308594 145.5 55.394531 145.394531 L 100.214844 85.894531 C 108.085938 75.515625 112.5 62.621094 112.5 49.394531 C 112.5 22.128906 86.917969 0 56.25 0 Z" fill="#000" fill-opacity="0.15" filter="url(#shadow)"/><path d="M 56.25 9.375 C 30.210938 9.375 9.375 30.210938 9.375 56.25 C 9.375 68.191406 13.289062 79.847656 20.753906 89.5 L 56.113281 136.214844 L 90.449219 91.425781 C 97.871094 81.566406 101.796875 69.855469 101.796875 57.875 C 101.796875 30.195312 81.089844 9.375 56.25 9.375 Z" fill="#fff"/><path d="M 56.25 23.4375 C 38.101562 23.4375 23.4375 38.101562 23.4375 56.25 C 23.4375 74.398438 38.101562 89.0625 56.25 89.0625 C 74.398438 89.0625 89.0625 74.398438 89.0625 56.25 C 89.0625 38.101562 74.398438 23.4375 56.25 23.4375 Z" fill="#f7f7f7"/><path d="M 56.25 33.75 C 43.347656 33.75 32.8125 44.285156 32.8125 57.1875 C 32.8125 70.089844 43.347656 80.625 56.25 80.625 C 69.152344 80.625 79.6875 70.089844 79.6875 57.1875 C 79.6875 44.285156 69.152344 33.75 56.25 33.75 Z" fill="#c1272d"/></svg>`;
+        const pinUrl = 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(pinSvg);
+        const hotelIcon = L.icon({
+            iconUrl: pinUrl,
+            iconSize: [30, 40],
+            iconAnchor: [15, 40],
+            popupAnchor: [0, -40],
+            className: 'lbhotel-marker-icon',
+        });
+
+        const markerById = {};
+        const bounds = [];
+
+        (hotels || [])
+            .filter((hotel) => hotel && Number.isFinite(hotel.lat) && Number.isFinite(hotel.lng))
+            .forEach((hotel) => {
+                const marker = L.marker([hotel.lat, hotel.lng], { icon: hotelIcon }).addTo(map);
+                marker.bindPopup(buildPopup(hotel));
+                bounds.push([hotel.lat, hotel.lng]);
+                markerById[String(hotel.id)] = marker;
+            });
+
+        if (bounds.length > 1) {
+            map.fitBounds(bounds, { padding: [40, 40] });
+        } else if (bounds.length === 1) {
+            map.setView(bounds[0], 13);
+        }
+
+        map.on('popupopen', (event) => {
+            const popupRoot = event.popup.getElement();
+            if (popupRoot) {
+                setupSliders(popupRoot);
+            }
+        });
+
+        return { markerById, bounds };
+    };
+
+    const focusOnHotel = (map, current, markerById, fallbackCenter) => {
+        if (!map) {
+            return;
+        }
+
+        const fallbackLat = Number(fallbackCenter && fallbackCenter.lat);
+        const fallbackLng = Number(fallbackCenter && fallbackCenter.lng);
+
+        window.setTimeout(() => {
+            map.invalidateSize();
+
+            if (current && Number.isFinite(current.lat) && Number.isFinite(current.lng)) {
+                map.setView([current.lat, current.lng], 15);
+                const target = markerById[String(current.id)];
+                if (target) {
+                    target.openPopup();
+                }
+                return;
+            }
+
+            if (Number.isFinite(fallbackLat) && Number.isFinite(fallbackLng)) {
+                map.setView([fallbackLat, fallbackLng], 6);
+            }
+        }, 250);
+    };
+
+    const createOverlay = () => {
+        const overlay = document.createElement('div');
+        overlay.className = 'lbhotel-popup-overlay';
+
+        const content = document.createElement('div');
+        content.className = 'lbhotel-popup-content';
+
+        const closeButton = document.createElement('button');
+        closeButton.type = 'button';
+        closeButton.className = 'lbhotel-popup-close';
+        closeButton.setAttribute('aria-label', 'Close popup');
+        closeButton.textContent = '✕';
+
+        const body = document.createElement('div');
+        body.className = 'lbhotel-popup-body';
+
+        content.appendChild(closeButton);
+        content.appendChild(body);
+        overlay.appendChild(content);
+        document.body.appendChild(overlay);
+
+        const destroy = () => {
+            document.removeEventListener('keydown', onKeyDown);
+            if (overlay.parentNode) {
+                overlay.parentNode.removeChild(overlay);
+            }
+        };
+
+        const onKeyDown = (event) => {
+            if (event.key === 'Escape' || event.key === 'Esc') {
+                destroy();
+            }
+        };
+
+        closeButton.addEventListener('click', destroy);
+        overlay.addEventListener('click', (event) => {
+            if (event.target === overlay) {
+                destroy();
+            }
+        });
+        document.addEventListener('keydown', onKeyDown);
+
+        return { overlay, content, body, destroy };
+    };
+
+    const openVirtualTourOverlay = (url, hotelName) => {
+        if (!url) {
+            return;
+        }
+
+        const overlay = createOverlay();
+        if (!overlay) {
+            return;
+        }
+
+        const iframe = document.createElement('iframe');
+        iframe.src = url;
+        iframe.title = hotelName ? `${hotelName} – Virtual Tour` : 'Virtual Tour';
+        iframe.loading = 'lazy';
+        iframe.allowFullscreen = true;
+        overlay.body.appendChild(iframe);
+    };
+
+    const openMapOverlay = (hotels, current, fallbackCenter) => {
+        const overlay = createOverlay();
+        if (!overlay) {
+            return;
+        }
+
+        if (typeof L === 'undefined') {
+            const message = document.createElement('p');
+            message.textContent = 'Map view is currently unavailable.';
+            message.style.padding = '2rem';
+            overlay.body.appendChild(message);
+            return;
+        }
+
+        const mapContainer = document.createElement('div');
+        mapContainer.className = 'lbhotel-popup-map';
+        overlay.body.appendChild(mapContainer);
+
+        window.setTimeout(() => {
+            const base = createBaseMap(mapContainer, fallbackCenter, { scrollWheelZoom: true });
+            if (!base) {
+                return;
+            }
+
+            const { markerById } = renderHotelsOnMap(base.map, hotels);
+            focusOnHotel(base.map, current, markerById, fallbackCenter);
+        }, 0);
+    };
+
+    const attachInfoCardHandlers = () => {
+        const cards = document.querySelectorAll('.lbhotel-info-card');
+        cards.forEach((card) => {
+            if (card.dataset.lbhotelIconsInitialised) {
+                return;
+            }
+
+            card.dataset.lbhotelIconsInitialised = 'true';
+
+            const hotelData = parseHotelFromCard(card);
+            const tourButton = card.querySelector('.lbhotel-icon--tour');
+            if (tourButton) {
+                tourButton.addEventListener('click', () => {
+                    const url = tourButton.dataset.tourUrl || (hotelData ? hotelData.virtualTourUrl : '');
+                    if (url) {
+                        openVirtualTourOverlay(url, hotelData ? hotelData.name : document.title);
+                    }
+                });
+            }
+
+            const mapButton = card.querySelector('.lbhotel-icon--map');
+            if (mapButton) {
+                mapButton.addEventListener('click', () => {
+                    const { hotels, current, fallbackCenter } = collectHotelsData(hotelData);
+                    openMapOverlay(hotels, current, fallbackCenter);
+                });
+            }
+        });
     };
 
     const buildDummyHotels = () => {
@@ -313,102 +629,20 @@
             return;
         }
 
-        const baseLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors',
-        });
-
-        const satelliteLayer = L.tileLayer(
-            'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
-            {
-                attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
-                maxZoom: 19,
-            }
-        );
-
-        const map = L.map(mapElement, {
-            center: [31.7917, -7.0926],
-            zoom: 6,
-            layers: [baseLayer],
-            scrollWheelZoom: false,
-        });
-
-        const layersControl = L.control.layers(
-            {
-                Map: baseLayer,
-                Satellite: satelliteLayer,
-            },
-            null,
-            { position: 'topright' }
-        ).addTo(map);
-
-        // Keep layers list visible without hover by forcing expanded state
-        if (layersControl && layersControl._container) {
-            layersControl._container.classList.add('leaflet-control-layers-expanded');
+        const { hotels, current, fallbackCenter } = collectHotelsData();
+        const base = createBaseMap(mapElement, fallbackCenter);
+        if (!base) {
+            return;
         }
 
-        const current = normaliseHotel(window.lbHotelSingleData ? window.lbHotelSingleData.currentHotel : null);
-        const hotels = current ? [current] : [];
-
-        if (current) {
-            if (Number.isFinite(current.lat) && Number.isFinite(current.lng)) {
-                map.setView([current.lat, current.lng], 13);
-            } else if (window.lbHotelSingleData && window.lbHotelSingleData.fallbackCenter) {
-                const fallback = window.lbHotelSingleData.fallbackCenter;
-                map.setView([fallback.lat, fallback.lng], 6);
-            }
-        }
-
-        // Custom SVG pin icon
-        const pinSvg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="150" zoomAndPan="magnify" viewBox="0 0 112.5 149.999998" height="200" preserveAspectRatio="xMidYMid meet" version="1.0"><defs><clipPath id="d8767f843b"><path d="M 0.910156 1.421875 L 110.671875 1.421875 L 110.671875 111.183594 L 0.910156 111.183594 Z M 0.910156 1.421875 " clip-rule="nonzero"/></clipPath><clipPath id="a0f5e86848"><path d="M 0 0.332031 L 112 0.332031 L 112 148 L 0 148 Z M 0 0.332031 " clip-rule="nonzero"/></clipPath></defs><g clip-path="url(#d8767f843b)"><path fill="#d50000" d="M 110.671875 56.304688 C 110.671875 58.101562 110.582031 59.894531 110.40625 61.683594 C 110.230469 63.472656 109.96875 65.25 109.617188 67.011719 C 109.265625 68.773438 108.832031 70.515625 108.308594 72.234375 C 107.785156 73.957031 107.183594 75.644531 106.492188 77.304688 C 105.804688 78.96875 105.039062 80.589844 104.191406 82.175781 C 103.34375 83.761719 102.421875 85.300781 101.421875 86.792969 C 100.425781 88.289062 99.355469 89.730469 98.214844 91.121094 C 97.074219 92.511719 95.867188 93.839844 94.597656 95.109375 C 93.328125 96.382812 91.996094 97.585938 90.605469 98.726562 C 89.21875 99.867188 87.773438 100.9375 86.28125 101.9375 C 84.785156 102.933594 83.246094 103.859375 81.660156 104.707031 C 80.074219 105.550781 78.453125 106.320312 76.792969 107.007812 C 75.132812 107.695312 73.441406 108.300781 71.722656 108.820312 C 70 109.34375 68.261719 109.78125 66.496094 110.128906 C 64.734375 110.480469 62.957031 110.746094 61.167969 110.921875 C 59.382812 111.097656 57.589844 111.183594 55.789062 111.183594 C 53.992188 111.183594 52.199219 111.097656 50.410156 110.921875 C 48.621094 110.746094 46.847656 110.480469 45.082031 110.128906 C 43.320312 109.78125 41.578125 109.34375 39.859375 108.820312 C 38.140625 108.300781 36.449219 107.695312 34.789062 107.007812 C 33.128906 106.320312 31.503906 105.550781 29.917969 104.707031 C 28.335938 103.859375 26.792969 102.933594 25.300781 101.9375 C 23.804688 100.9375 22.363281 99.867188 20.972656 98.726562 C 19.585938 97.585938 18.253906 96.382812 16.984375 95.109375 C 15.710938 93.839844 14.507812 92.511719 13.367188 91.121094 C 12.226562 89.730469 11.15625 88.289062 10.160156 86.792969 C 9.160156 85.300781 8.238281 83.761719 7.390625 82.175781 C 6.542969 80.589844 5.773438 78.96875 5.085938 77.304688 C 4.398438 75.644531 3.792969 73.957031 3.273438 72.234375 C 2.75 70.515625 2.316406 68.773438 1.964844 67.011719 C 1.613281 65.25 1.351562 63.472656 1.171875 61.683594 C 0.996094 59.894531 0.910156 58.101562 0.910156 56.304688 C 0.910156 54.507812 0.996094 52.714844 1.171875 50.925781 C 1.351562 49.136719 1.613281 47.359375 1.964844 45.597656 C 2.316406 43.835938 2.75 42.09375 3.273438 40.375 C 3.792969 38.652344 4.398438 36.960938 5.085938 35.300781 C 5.773438 33.640625 6.542969 32.019531 7.390625 30.433594 C 8.238281 28.847656 9.160156 27.308594 10.160156 25.8125 C 11.15625 24.320312 12.226562 22.878906 13.367188 21.488281 C 14.507812 20.097656 15.710938 18.769531 16.984375 17.496094 C 18.253906 16.226562 19.585938 15.019531 20.972656 13.878906 C 22.363281 12.742188 23.804688 11.671875 25.300781 10.671875 C 26.792969 9.671875 28.335938 8.75 29.917969 7.902344 C 31.503906 7.054688 33.128906 6.289062 34.789062 5.601562 C 36.449219 4.914062 38.140625 4.308594 39.859375 3.785156 C 41.578125 3.265625 43.320312 2.828125 45.082031 2.476562 C 46.847656 2.128906 48.621094 1.863281 50.410156 1.6875 C 52.199219 1.511719 53.992188 1.421875 55.789062 1.421875 C 57.589844 1.421875 59.382812 1.511719 61.167969 1.6875 C 62.957031 1.863281 64.734375 2.128906 66.496094 2.476562 C 68.261719 2.828125 70 3.265625 71.722656 3.785156 C 73.441406 4.308594 75.132812 4.914062 76.792969 5.601562 C 78.453125 6.289062 80.074219 7.054688 81.660156 7.902344 C 83.246094 8.75 84.785156 9.671875 86.28125 10.671875 C 87.773438 11.671875 89.21875 12.742188 90.605469 13.878906 C 91.996094 15.019531 93.328125 16.226562 94.597656 17.496094 C 95.867188 18.769531 97.074219 20.097656 98.214844 21.488281 C 99.355469 22.878906 100.425781 24.320312 101.421875 25.8125 C 102.421875 27.308594 103.34375 28.847656 104.191406 30.433594 C 105.039062 32.019531 105.804688 33.640625 106.492188 35.300781 C 107.183594 36.960938 107.785156 38.652344 108.308594 40.375 C 108.832031 42.09375 109.265625 43.835938 109.617188 45.597656 C 109.96875 47.359375 110.230469 49.136719 110.40625 50.925781 C 110.582031 52.714844 110.671875 54.507812 110.671875 56.304688 Z M 110.671875 56.304688 " fill-opacity="1" fill-rule="nonzero"/></g><path fill="#1b5e20" d="M 43.304688 75.511719 L 48.070312 60.839844 L 35.601562 51.769531 L 51.027344 51.769531 L 55.789062 37.097656 L 60.574219 51.769531 L 75.980469 51.769531 L 63.511719 60.835938 L 68.277344 75.511719 L 55.808594 66.445312 Z M 58.453125 64.511719 L 62.316406 67.328125 L 60.847656 62.769531 Z M 50.734375 62.769531 L 49.265625 67.328125 L 53.125 64.511719 Z M 51.742188 59.644531 L 55.789062 62.582031 L 59.820312 59.644531 L 58.285156 54.914062 L 53.296875 54.914062 Z M 45.234375 54.914062 L 49.09375 57.714844 L 50 54.914062 Z M 61.582031 54.914062 L 62.484375 57.714844 L 66.363281 54.914062 Z M 54.304688 51.769531 L 57.273438 51.769531 L 55.789062 47.207031 Z M 54.304688 51.769531 " fill-opacity="1" fill-rule="nonzero"/><g clip-path="url(#a0f5e86848)"><path fill="#1b5e20" d="M 111.859375 56.074219 C 111.800781 25.238281 86.753906 0.28125 55.917969 0.339844 C 25.082031 0.402344 0.132812 25.445312 0.1875 56.285156 C 0.207031 66.980469 3.441406 76.835938 8.460938 85.441406 C 19.804688 104.878906 56.195312 147.820312 56.195312 147.820312 C 56.195312 147.820312 92.925781 104.105469 104.109375 84.5625 C 108.921875 76.140625 111.882812 66.472656 111.859375 56.074219 Z M 55.941406 13.234375 C 79.664062 13.1875 98.921875 32.382812 98.96875 56.097656 C 99.011719 79.8125 79.824219 99.078125 56.101562 99.128906 C 32.390625 99.167969 13.128906 79.976562 13.082031 56.261719 C 13.035156 32.542969 32.222656 13.277344 55.941406 13.234375 Z M 55.941406 13.234375 " fill-opacity="1" fill-rule="nonzero"/></g></svg>`;
-        const pinUrl = 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(pinSvg);
-        const hotelIcon = L.icon({
-            iconUrl: pinUrl,
-            iconSize: [30, 40],
-            iconAnchor: [15, 40],
-            popupAnchor: [0, -40],
-            className: 'lbhotel-marker-icon'
-        });
-
-        const markers = hotels
-            .map(normaliseHotel)
-            .filter((hotel) => Number.isFinite(hotel.lat) && Number.isFinite(hotel.lng));
-
-        const bounds = [];
-        const markerById = {};
-
-        markers.forEach((hotel) => {
-            const marker = L.marker([hotel.lat, hotel.lng], { icon: hotelIcon }).addTo(map);
-            marker.bindPopup(buildPopup(hotel));
-            bounds.push([hotel.lat, hotel.lng]);
-            markerById[String(hotel.id)] = marker;
-        });
-
-        if (bounds.length > 1) {
-            map.fitBounds(bounds, { padding: [40, 40] });
-        }
-
-        map.on('popupopen', (event) => {
-            const popupRoot = event.popup.getElement();
-            if (popupRoot) {
-                setupSliders(popupRoot);
-            }
-        });
-
-        window.setTimeout(() => {
-            map.invalidateSize();
-            // On single hotel page: focus and open popup for current hotel
-            if (current && Number.isFinite(current.lat) && Number.isFinite(current.lng)) {
-                const target = markerById[String(current.id)];
-                map.setView([current.lat, current.lng], 15);
-                if (target) {
-                    target.openPopup();
-                }
-            }
-        }, 250);
+        const { markerById } = renderHotelsOnMap(base.map, hotels);
+        focusOnHotel(base.map, current, markerById, fallbackCenter);
     };
+
 
     document.addEventListener('DOMContentLoaded', () => {
         setupSliders();
+        attachInfoCardHandlers();
         initMap();
     });
 })();

--- a/single-lbhotel_hotel.php
+++ b/single-lbhotel_hotel.php
@@ -83,6 +83,7 @@ $current_payload = array(
     'mapUrl'     => $map_url ? esc_url_raw( $map_url ) : '',
     'permalink'  => $current_id ? get_permalink( $current_id ) : '',
     'images'     => $gallery_urls,
+    'virtualTourUrl' => $virtual_tour_url ? esc_url_raw( $virtual_tour_url ) : '',
 );
 
 wp_localize_script(
@@ -114,8 +115,14 @@ get_header();
                                 </section>
                             <?php endif; ?>
 
-                            <section class="lbhotel-info-card" aria-label="<?php esc_attr_e( 'Hotel highlight', 'lbhotel' ); ?>">
+                            <?php $info_card_payload = $current_payload; ?>
+                            <section class="lbhotel-info-card" aria-label="<?php esc_attr_e( 'Hotel highlight', 'lbhotel' ); ?>"
+                                data-hotel='<?php echo esc_attr( wp_json_encode( $info_card_payload ) ); ?>'>
                                 <div class="lbhotel-info-card__media">
+                                    <div class="lbhotel-info-card__icons">
+                                        <button type="button" class="lbhotel-icon lbhotel-icon--tour" aria-label="<?php esc_attr_e( 'Virtual Tour', 'lbhotel' ); ?>" data-tour-url="<?php echo esc_url( $virtual_tour_url ); ?>">🎥</button>
+                                        <button type="button" class="lbhotel-icon lbhotel-icon--map" aria-label="<?php esc_attr_e( 'Map View', 'lbhotel' ); ?>">🗺️</button>
+                                    </div>
                                     <?php if ( $gallery_urls ) : ?>
                                         <div class="lbhotel-slider" data-lbhotel-slider>
                                             <div class="lbhotel-slider__track">


### PR DESCRIPTION
## Summary
- add virtual tour and map buttons to hotel info cards with supporting data attributes
- style icon badges and reusable fullscreen overlay containers for tour and map content
- extend single and archive JavaScript to open tour iframes and Leaflet maps with shared hotel data
- enqueue Leaflet assets and localize hotel datasets on the archive template

## Testing
- php -l single-lbhotel_hotel.php
- php -l archive-lbhotel_hotel.php

------
https://chatgpt.com/codex/tasks/task_e_68e1a4135f7483249da6e7618ac201ef