### PR TITLE
Update hotel shortcodes to use canonical meta

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -35,6 +35,15 @@ function lbhotel_shortcode_list( $atts ) {
         'lbhotel_list'
     );
 
+    // Ensure front-end assets are available when rendering the shortcode outside plugin templates.
+    if ( wp_style_is( 'lbhotel-public', 'registered' ) ) {
+        wp_enqueue_style( 'lbhotel-public' );
+    }
+
+    if ( wp_script_is( 'lbhotel-public', 'registered' ) ) {
+        wp_enqueue_script( 'lbhotel-public' );
+    }
+
     if ( isset( $_GET['lbhotel_city'] ) ) {
         $atts['city'] = sanitize_text_field( wp_unslash( $_GET['lbhotel_city'] ) );
     }
@@ -57,31 +66,33 @@ function lbhotel_shortcode_list( $atts ) {
 
     if ( ! empty( $atts['city'] ) ) {
         $meta_query[] = array(
-            'key'     => 'lbhotel_city',
+            'key'     => 'vm_city',
             'value'   => sanitize_text_field( $atts['city'] ),
             'compare' => 'LIKE',
         );
     }
 
-    if ( ! empty( $atts['stars'] ) ) {
+    if ( '' !== $atts['stars'] && null !== $atts['stars'] ) {
         $meta_query[] = array(
-            'key'   => 'lbhotel_star_rating',
-            'value' => lbhotel_sanitize_int( $atts['stars'] ),
+            'key'   => 'vm_rating',
+            'value' => lbhotel_sanitize_decimal( $atts['stars'] ),
+            'compare' => '>=',
+            'type'  => 'NUMERIC',
+        );
+    }
+
+    if ( ! empty( $atts['hotel_type'] ) ) {
+        $meta_query[] = array(
+            'key'   => 'vm_hotel_type',
+            'value' => sanitize_text_field( $atts['hotel_type'] ),
         );
     }
 
     if ( ! empty( $meta_query ) ) {
+        if ( count( $meta_query ) > 1 ) {
+            $meta_query['relation'] = 'AND';
+        }
         $query_args['meta_query'] = $meta_query;
-    }
-
-    if ( ! empty( $atts['hotel_type'] ) ) {
-        $query_args['tax_query'] = array(
-            array(
-                'taxonomy' => 'lbhotel_hotel_type',
-                'field'    => 'slug',
-                'terms'    => sanitize_text_field( $atts['hotel_type'] ),
-            ),
-        );
     }
 
     $hotels = new WP_Query( $query_args );
@@ -118,6 +129,14 @@ function lbhotel_shortcode_single( $atts ) {
 
     if ( ! $post || 'lbhotel_hotel' !== $post->post_type ) {
         return '';
+    }
+
+    if ( wp_style_is( 'lbhotel-public', 'registered' ) ) {
+        wp_enqueue_style( 'lbhotel-public' );
+    }
+
+    if ( wp_script_is( 'lbhotel-public', 'registered' ) ) {
+        wp_enqueue_script( 'lbhotel-public' );
     }
 
     ob_start();

--- a/shortcodes/list.php
+++ b/shortcodes/list.php
@@ -12,25 +12,35 @@ if ( ! isset( $query ) || ! $query instanceof WP_Query ) {
     return;
 }
 
-$map_data = array();
+$map_data           = array();
+$hotel_type_options = array();
+
+$category_fields = lbhotel_get_category_field_definitions();
+if ( isset( $category_fields['vm_hotel_type']['options'] ) && is_array( $category_fields['vm_hotel_type']['options'] ) ) {
+    $hotel_type_options = $category_fields['vm_hotel_type']['options'];
+}
 
 if ( $query->have_posts() ) {
     while ( $query->have_posts() ) {
         $query->the_post();
-        $lat = get_post_meta( get_the_ID(), 'lbhotel_latitude', true );
-        $lng = get_post_meta( get_the_ID(), 'lbhotel_longitude', true );
+        $post_id   = get_the_ID();
+        $latitude  = lbhotel_get_meta_value( $post_id, 'vm_latitude', '' );
+        $longitude = lbhotel_get_meta_value( $post_id, 'vm_longitude', '' );
 
-        if ( $lat && $lng ) {
+        if ( '' !== $latitude && '' !== $longitude ) {
             $map_data[] = array(
-                'title'               => get_the_title(),
-                'lat'                 => (float) $lat,
-                'lng'                 => (float) $lng,
-                'star_rating'         => (int) get_post_meta( get_the_ID(), 'lbhotel_star_rating', true ),
-                'avg_price_per_night' => get_post_meta( get_the_ID(), 'lbhotel_avg_price_per_night', true ),
-                'currency'            => lbhotel_get_option( 'default_currency' ),
-                'booking_url'         => get_post_meta( get_the_ID(), 'lbhotel_booking_url', true ),
-                'permalink'           => get_permalink(),
-                'address'             => get_post_meta( get_the_ID(), 'lbhotel_address', true ),
+                'title'         => get_the_title(),
+                'lat'           => (float) $latitude,
+                'lng'           => (float) $longitude,
+                'rating'        => (float) lbhotel_get_meta_value( $post_id, 'vm_rating', 0 ),
+                'booking_url'   => lbhotel_get_meta_value( $post_id, 'vm_booking_url', '' ),
+                'permalink'     => get_permalink(),
+                'virtual_tour'  => lbhotel_get_meta_value( $post_id, 'vm_virtual_tour_url', '' ),
+                'map_url'       => lbhotel_get_meta_value( $post_id, 'vm_google_map_url', '' ),
+                'city'          => lbhotel_get_meta_value( $post_id, 'vm_city', '' ),
+                'region'        => lbhotel_get_meta_value( $post_id, 'vm_region', '' ),
+                'country'       => lbhotel_get_meta_value( $post_id, 'vm_country', '' ),
+                'streetAddress' => lbhotel_get_meta_value( $post_id, 'vm_street_address', '' ),
             );
         }
     }
@@ -48,29 +58,30 @@ $filters_action = esc_url( remove_query_arg( array( 'paged' ) ) );
             <input type="text" name="lbhotel_city" value="<?php echo isset( $_GET['lbhotel_city'] ) ? esc_attr( wp_unslash( $_GET['lbhotel_city'] ) ) : esc_attr( $atts['city'] ); ?>" />
         </label>
         <label>
-            <?php esc_html_e( 'Stars', 'lbhotel' ); ?>
+            <?php esc_html_e( 'Rating', 'lbhotel' ); ?>
             <select name="lbhotel_stars">
                 <option value=""><?php esc_html_e( 'Any', 'lbhotel' ); ?></option>
                 <?php for ( $i = 1; $i <= 5; $i++ ) : ?>
-                    <option value="<?php echo esc_attr( $i ); ?>" <?php selected( isset( $_GET['lbhotel_stars'] ) ? (int) $_GET['lbhotel_stars'] : (int) $atts['stars'], $i ); ?>><?php echo esc_html( sprintf( _n( '%d Star', '%d Stars', $i, 'lbhotel' ), $i ) ); ?></option>
+                    <option value="<?php echo esc_attr( $i ); ?>" <?php selected( isset( $_GET['lbhotel_stars'] ) ? (int) $_GET['lbhotel_stars'] : (int) $atts['stars'], $i ); ?>><?php echo esc_html( sprintf( _n( '%d star & up', '%d stars & up', $i, 'lbhotel' ), $i ) ); ?></option>
                 <?php endfor; ?>
             </select>
         </label>
-        <label>
-            <?php esc_html_e( 'Hotel type', 'lbhotel' ); ?>
-            <?php
-            wp_dropdown_categories(
-                array(
-                    'show_option_all' => __( 'Any type', 'lbhotel' ),
-                    'taxonomy'        => 'lbhotel_hotel_type',
-                    'name'            => 'lbhotel_type',
-                    'hide_empty'      => false,
-                    'selected'        => isset( $_GET['lbhotel_type'] ) ? sanitize_text_field( wp_unslash( $_GET['lbhotel_type'] ) ) : $atts['hotel_type'],
-                    'value_field'     => 'slug',
-                )
-            );
-            ?>
-        </label>
+        <?php if ( ! empty( $hotel_type_options ) ) : ?>
+            <label>
+                <?php esc_html_e( 'Hotel type', 'lbhotel' ); ?>
+                <select name="lbhotel_type">
+                    <option value=""><?php esc_html_e( 'Any type', 'lbhotel' ); ?></option>
+                    <?php
+                    $selected_type = isset( $_GET['lbhotel_type'] ) ? sanitize_text_field( wp_unslash( $_GET['lbhotel_type'] ) ) : $atts['hotel_type'];
+                    foreach ( $hotel_type_options as $option_value => $option_label ) :
+                        ?>
+                        <option value="<?php echo esc_attr( $option_value ); ?>" <?php selected( $selected_type, $option_value ); ?>><?php echo esc_html( $option_label ); ?></option>
+                        <?php
+                    endforeach;
+                    ?>
+                </select>
+            </label>
+        <?php endif; ?>
         <button type="submit" class="lbhotel-button lbhotel-button--primary"><?php esc_html_e( 'Filter', 'lbhotel' ); ?></button>
     </form>
 
@@ -83,12 +94,34 @@ $filters_action = esc_url( remove_query_arg( array( 'paged' ) ) );
             <?php
             while ( $query->have_posts() ) {
                 $query->the_post();
-                $meta = array(
-                    'city'                => get_post_meta( get_the_ID(), 'lbhotel_city', true ),
-                    'avg_price_per_night' => get_post_meta( get_the_ID(), 'lbhotel_avg_price_per_night', true ),
-                    'star_rating'         => (int) get_post_meta( get_the_ID(), 'lbhotel_star_rating', true ),
-                );
-                $image = get_the_post_thumbnail_url( get_the_ID(), 'large' );
+                $post_id      = get_the_ID();
+                $city         = lbhotel_get_meta_value( $post_id, 'vm_city', '' );
+                $region       = lbhotel_get_meta_value( $post_id, 'vm_region', '' );
+                $country      = lbhotel_get_meta_value( $post_id, 'vm_country', '' );
+                $hotel_type   = lbhotel_get_meta_value( $post_id, 'vm_hotel_type', '' );
+                $rating_value = lbhotel_get_meta_value( $post_id, 'vm_rating', '' );
+                $virtual_tour = lbhotel_get_meta_value( $post_id, 'vm_virtual_tour_url', '' );
+                $map_url      = lbhotel_get_meta_value( $post_id, 'vm_google_map_url', '' );
+                $booking_url  = lbhotel_get_meta_value( $post_id, 'vm_booking_url', '' );
+                $image        = get_the_post_thumbnail_url( $post_id, 'large' );
+                $excerpt      = get_the_excerpt();
+
+                $location_parts = array_filter( array( $city, $region, $country ) );
+                $location_line  = implode( ', ', $location_parts );
+
+                $rating_markup = '';
+
+                if ( '' !== $rating_value ) {
+                    $numeric_rating  = max( 0, min( 5, (float) $rating_value ) );
+                    $rounded_rating  = round( $numeric_rating * 2 ) / 2;
+                    $rating_label    = sprintf( __( 'Rated %s out of 5', 'lbhotel' ), number_format_i18n( $rounded_rating, 1 ) );
+                    $rating_markup   = sprintf(
+                        '<div class="lbhotel-rating" data-lbhotel-rating="%1$s"><span class="lbhotel-rating__stars" aria-hidden="true"></span><span class="screen-reader-text">%2$s</span><span class="lbhotel-rating__value">%3$s</span></div>',
+                        esc_attr( $rounded_rating ),
+                        esc_html( $rating_label ),
+                        esc_html( number_format_i18n( $rounded_rating, 1 ) )
+                    );
+                }
                 ?>
                 <article class="lbhotel-card">
                     <div class="lbhotel-card__image" style="<?php echo $image ? 'background-image:url(' . esc_url( $image ) . ');' : ''; ?>">
@@ -97,15 +130,31 @@ $filters_action = esc_url( remove_query_arg( array( 'paged' ) ) );
                     <div class="lbhotel-card__body">
                         <h3 class="lbhotel-card__title"><?php the_title(); ?></h3>
                         <div class="lbhotel-card__meta">
-                            <span class="lbhotel-stars"><?php echo str_repeat( '★', $meta['star_rating'] ); ?></span>
-                            <span class="lbhotel-price"><?php echo esc_html( lbhotel_get_option( 'default_currency' ) ); ?> <?php echo esc_html( $meta['avg_price_per_night'] ); ?></span>
+                            <?php echo $rating_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                            <?php if ( $hotel_type ) : ?>
+                                <span class="lbhotel-card__tag"><?php echo esc_html( $hotel_type ); ?></span>
+                            <?php endif; ?>
                         </div>
-                        <p><?php echo esc_html( $meta['city'] ); ?></p>
+                        <?php if ( $location_line ) : ?>
+                            <p class="lbhotel-card__location"><?php echo esc_html( $location_line ); ?></p>
+                        <?php endif; ?>
+                        <?php if ( $excerpt ) : ?>
+                            <p class="lbhotel-card__excerpt"><?php echo esc_html( wp_trim_words( $excerpt, 30 ) ); ?></p>
+                        <?php endif; ?>
                         <div class="lbhotel-card__actions">
-                            <a class="lbhotel-button lbhotel-button--primary" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View hotel', 'lbhotel' ); ?></a>
-                            <?php $booking = get_post_meta( get_the_ID(), 'lbhotel_booking_url', true ); ?>
-                            <?php if ( $booking ) : ?>
-                                <a class="lbhotel-button lbhotel-button--ghost" href="<?php echo esc_url( $booking ); ?>" target="_blank" rel="noopener">
+                            <a class="lbhotel-button lbhotel-button--primary" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View details', 'lbhotel' ); ?></a>
+                            <?php if ( $virtual_tour ) : ?>
+                                <a class="lbhotel-button lbhotel-button--ghost" href="<?php echo esc_url( $virtual_tour ); ?>" target="_blank" rel="noopener">
+                                    <?php esc_html_e( 'Virtual tour', 'lbhotel' ); ?>
+                                </a>
+                            <?php endif; ?>
+                            <?php if ( $map_url ) : ?>
+                                <a class="lbhotel-button lbhotel-button--ghost" href="<?php echo esc_url( $map_url ); ?>" target="_blank" rel="noopener">
+                                    <?php esc_html_e( 'Map', 'lbhotel' ); ?>
+                                </a>
+                            <?php endif; ?>
+                            <?php if ( $booking_url ) : ?>
+                                <a class="lbhotel-button lbhotel-button--ghost" href="<?php echo esc_url( $booking_url ); ?>" target="_blank" rel="noopener">
                                     <?php esc_html_e( 'Book', 'lbhotel' ); ?>
                                 </a>
                             <?php endif; ?>


### PR DESCRIPTION
## Summary
- ensure hotel shortcodes enqueue public assets and query the canonical vm_* meta values
- refresh the list shortcode output with rating, location, and action buttons that mirror the new layouts
- update the single shortcode template to render vm_* data, gallery, and contextual quick links

## Testing
- php -l includes/shortcodes.php
- php -l shortcodes/list.php
- php -l shortcodes/single.php

------
https://chatgpt.com/codex/tasks/task_e_68e54fa0e9b08324a42b2311db8fcf85