### PR TITLE
Add shared layout and dynamic fields to place templates

### DIFF
--- a/all-hotel.css
+++ b/all-hotel.css
@@ -1,0 +1,194 @@
+:root {
+    --lbhotel-primary: #c1272d;
+    --lbhotel-secondary: #006233;
+    --lbhotel-cream: #f8f3eb;
+    --lbhotel-muted: #5c5c5c;
+}
+
+.lbhotel-archive {
+    margin: 0 auto 4rem;
+    max-width: 1200px;
+    padding: 2rem 1.5rem 4rem;
+}
+
+.lbhotel-archive__header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.lbhotel-archive__title {
+    margin: 0;
+    font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.lbhotel-archive__intro {
+    max-width: 720px;
+    margin: 1rem auto 0;
+    color: var(--lbhotel-muted);
+}
+
+.lbhotel-archive__grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.lbhotel-archive__item {
+    background: #fff;
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+}
+
+.lbhotel-archive__thumbnail {
+    position: relative;
+    display: block;
+    aspect-ratio: 4 / 3;
+    background: rgba(0, 0, 0, 0.06);
+}
+
+.lbhotel-archive__thumb {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    border-bottom: 4px solid rgba(193, 39, 45, 0.35);
+}
+
+.lbhotel-archive__placeholder {
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(45deg, rgba(0,0,0,0.05), rgba(0,0,0,0.05) 20px, rgba(0,0,0,0.12) 20px, rgba(0,0,0,0.12) 40px);
+}
+
+.lbhotel-archive__body {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+    flex: 1;
+}
+
+.lbhotel-archive__name {
+    margin: 0;
+    font-size: 1.35rem;
+}
+
+.lbhotel-archive__name a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.lbhotel-archive__rating {
+    display: flex;
+    align-items: center;
+}
+
+.lbhotel-rating--compact .lbhotel-rating__stars {
+    font-size: 1rem;
+}
+
+.lbhotel-rating--compact .lbhotel-rating__value {
+    display: none;
+}
+
+.lbhotel-archive__location {
+    margin: 0;
+    color: var(--lbhotel-muted);
+}
+
+.lbhotel-archive__excerpt {
+    margin: 0;
+    color: var(--lbhotel-muted);
+    font-size: 0.95rem;
+}
+
+.lbhotel-archive__highlights {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.45rem;
+}
+
+.lbhotel-archive__highlights li {
+    display: flex;
+    gap: 0.45rem;
+    font-size: 0.95rem;
+}
+
+.lbhotel-archive__highlight-label {
+    font-weight: 600;
+    color: var(--lbhotel-secondary);
+}
+
+.lbhotel-archive__highlight-value {
+    color: var(--lbhotel-muted);
+}
+
+.lbhotel-archive__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: auto;
+}
+
+.lbhotel-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem 1.4rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border: none;
+    cursor: pointer;
+}
+
+.lbhotel-button:hover,
+.lbhotel-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
+}
+
+.lbhotel-button--primary {
+    background: var(--lbhotel-primary);
+    color: #fff;
+}
+
+.lbhotel-button--ghost {
+    background: transparent;
+    color: var(--lbhotel-primary);
+    border: 1px solid currentColor;
+}
+
+.lbhotel-archive__contact {
+    margin: 0;
+    font-weight: 600;
+    color: var(--lbhotel-primary);
+}
+
+.lbhotel-archive__pagination {
+    margin-top: 3rem;
+    text-align: center;
+}
+
+.lbhotel-archive__pagination .page-numbers {
+    display: inline-block;
+    margin: 0 0.35rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    text-decoration: none;
+    background: rgba(0, 0, 0, 0.05);
+}
+
+.lbhotel-archive__pagination .page-numbers.current,
+.lbhotel-archive__pagination .page-numbers:hover,
+.lbhotel-archive__pagination .page-numbers:focus-visible {
+    background: var(--lbhotel-primary);
+    color: #fff;
+}

--- a/all-hotel.js
+++ b/all-hotel.js
@@ -1,0 +1,3 @@
+(function () {
+    // Placeholder for archive level enhancements.
+})();

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -135,3 +135,182 @@ function lbhotel_bootstrap_blocks() {
     // Placeholder for block registration using block.json files.
 }
 
+/**
+ * Sanitize rating values ensuring they are between 0 and 5 with one decimal precision.
+ *
+ * @param mixed $value Raw rating value.
+ * @return float
+ */
+function lbhotel_sanitize_rating( $value ) {
+    $numeric = lbhotel_sanitize_decimal( $value );
+
+    if ( $numeric < 0 ) {
+        $numeric = 0;
+    }
+
+    if ( $numeric > 5 ) {
+        $numeric = 5;
+    }
+
+    return round( $numeric, 1 );
+}
+
+/**
+ * Provide a mapping between Virtual Maroc meta keys and legacy meta keys.
+ *
+ * @return array<string,string>
+ */
+function lbhotel_get_vm_meta_key_map() {
+    return array(
+        'vm_booking_url'          => 'lbhotel_booking_url',
+        'vm_room_types'           => 'lbhotel_room_types',
+        'vm_hotel_type'           => 'lbhotel_hotel_type',
+        'vm_menu_url'             => 'lbhotel_menu_url',
+        'vm_specialties'          => 'lbhotel_specialties',
+        'vm_opening_hours'        => 'lbhotel_opening_hours',
+        'vm_event_datetime'       => 'lbhotel_event_date_time',
+        'vm_ticket_url'           => 'lbhotel_ticket_url',
+        'vm_event_type'           => 'lbhotel_event_type',
+        'vm_activity_type'        => 'lbhotel_activity_type',
+        'vm_seasonality'          => 'lbhotel_seasonality',
+        'vm_product_categories'   => 'lbhotel_product_categories',
+        'vm_sales_url'            => 'lbhotel_sales_url',
+        'vm_sport_type'           => 'lbhotel_sport_type',
+        'vm_equipment_rental_url' => 'lbhotel_equipment_rental_url',
+        'vm_ticket_info_url'      => 'lbhotel_ticket_price_url',
+        'vm_virtual_tour_url'     => 'lbhotel_virtual_tour_url',
+        'vm_google_map_url'       => 'lbhotel_google_maps_url',
+        'vm_contact_phone'        => 'lbhotel_contact_phone',
+        'vm_street_address'       => 'lbhotel_address',
+        'vm_city'                 => 'lbhotel_city',
+        'vm_region'               => 'lbhotel_region',
+        'vm_country'              => 'lbhotel_country',
+        'vm_postal_code'          => 'lbhotel_postal_code',
+        'vm_latitude'             => 'lbhotel_latitude',
+        'vm_longitude'            => 'lbhotel_longitude',
+        'vm_gallery'              => 'lbhotel_gallery_images',
+        'vm_rating'               => 'lbhotel_star_rating',
+    );
+}
+
+/**
+ * Retrieve meta value prioritising Virtual Maroc keys with fallback to legacy keys.
+ *
+ * @param int    $post_id  Post ID.
+ * @param string $meta_key Primary meta key.
+ * @param mixed  $default  Default value if none stored.
+ * @return mixed
+ */
+function lbhotel_get_meta_with_fallback( $post_id, $meta_key, $default = '' ) {
+    $value = get_post_meta( $post_id, $meta_key, true );
+
+    if ( '' !== $value && null !== $value ) {
+        return $value;
+    }
+
+    $map = lbhotel_get_vm_meta_key_map();
+
+    if ( isset( $map[ $meta_key ] ) ) {
+        $value = get_post_meta( $post_id, $map[ $meta_key ], true );
+    } elseif ( 0 === strpos( $meta_key, 'vm_' ) ) {
+        $legacy_key = 'lbhotel_' . substr( $meta_key, 3 );
+        $value      = get_post_meta( $post_id, $legacy_key, true );
+    }
+
+    if ( '' === $value || null === $value ) {
+        return $default;
+    }
+
+    return $value;
+}
+
+/**
+ * Retrieve a numeric meta value with fallback handling.
+ *
+ * @param int    $post_id  Post ID.
+ * @param string $meta_key Meta key.
+ * @param float  $default  Default value.
+ * @return float
+ */
+function lbhotel_get_numeric_meta_with_fallback( $post_id, $meta_key, $default = 0.0 ) {
+    $value = lbhotel_get_meta_with_fallback( $post_id, $meta_key, $default );
+
+    if ( '' === $value || null === $value ) {
+        return (float) $default;
+    }
+
+    return lbhotel_sanitize_decimal( $value );
+}
+
+/**
+ * Retrieve the rating value for a post.
+ *
+ * @param int $post_id Post ID.
+ * @return float
+ */
+function lbhotel_get_rating_value( $post_id ) {
+    $rating = lbhotel_get_numeric_meta_with_fallback( $post_id, 'vm_rating', 0 );
+
+    if ( $rating <= 0 ) {
+        $rating = lbhotel_get_numeric_meta_with_fallback( $post_id, 'lbhotel_star_rating', 0 );
+    }
+
+    if ( $rating <= 0 ) {
+        $default = lbhotel_get_option( 'default_star_rating' );
+        if ( null !== $default ) {
+            $rating = (float) $default;
+        }
+    }
+
+    return max( 0, min( 5, round( $rating, 1 ) ) );
+}
+
+/**
+ * Build accessible rating markup from a numeric rating value.
+ *
+ * @param float $rating Numeric rating between 0 and 5.
+ * @param array $args   Optional arguments.
+ * @return string
+ */
+function lbhotel_get_rating_markup( $rating, $args = array() ) {
+    $defaults = array(
+        'show_value' => true,
+        'class'      => 'lbhotel-rating',
+    );
+
+    $args   = wp_parse_args( $args, $defaults );
+    $rating = max( 0, min( 5, (float) $rating ) );
+
+    if ( $rating <= 0 ) {
+        return '';
+    }
+
+    $rounded_half = round( $rating * 2 ) / 2;
+    $full_stars   = floor( $rounded_half );
+    $has_half     = $rounded_half - $full_stars >= 0.5;
+
+    $stars_markup = '';
+
+    for ( $i = 1; $i <= 5; $i++ ) {
+        if ( $i <= $full_stars ) {
+            $stars_markup .= '<span class="lbhotel-rating__star is-full" aria-hidden="true">★</span>';
+        } elseif ( $has_half && $i === $full_stars + 1 ) {
+            $stars_markup .= '<span class="lbhotel-rating__star is-half" aria-hidden="true">☆</span>';
+        } else {
+            $stars_markup .= '<span class="lbhotel-rating__star is-empty" aria-hidden="true">☆</span>';
+        }
+    }
+
+    $output  = '<div class="' . esc_attr( $args['class'] ) . '" data-lbhotel-rating="' . esc_attr( $rounded_half ) . '">';
+    $output .= '<span class="lbhotel-rating__stars">' . $stars_markup . '</span>';
+    $output .= '<span class="screen-reader-text">' . esc_html( sprintf( __( 'Rated %s out of 5', 'lbhotel' ), number_format_i18n( $rounded_half, 1 ) ) ) . '</span>';
+
+    if ( $args['show_value'] ) {
+        $output .= '<span class="lbhotel-rating__value">' . esc_html( number_format_i18n( $rounded_half, 1 ) ) . '</span>';
+    }
+
+    $output .= '</div>';
+
+    return $output;
+}
+

--- a/includes/place-fields.php
+++ b/includes/place-fields.php
@@ -128,6 +128,18 @@ function lbhotel_get_global_field_definitions() {
             'sanitize_callback' => 'lbhotel_sanitize_phone',
             'section'           => 'details',
         ),
+        'vm_rating'                => array(
+            'label'             => __( 'Rating (0-5)', 'lbhotel' ),
+            'type'              => 'number',
+            'input'             => 'number',
+            'sanitize_callback' => 'lbhotel_sanitize_rating',
+            'section'           => 'details',
+            'attributes'        => array(
+                'min'  => '0',
+                'max'  => '5',
+                'step' => '0.1',
+            ),
+        ),
         'lbhotel_gallery_images'   => array(
             'label'             => __( 'Gallery Images', 'lbhotel' ),
             'type'              => 'array',
@@ -342,4 +354,158 @@ function lbhotel_get_fields_for_category( $category_slug ) {
     }
 
     return $fields;
+}
+
+/**
+ * Provide display configuration for each category in the front-end templates.
+ *
+ * @return array<string,array<string,mixed>>
+ */
+function lbhotel_get_category_display_config() {
+    return array(
+        'hotels' => array(
+            'highlights' => array(
+                'vm_hotel_type' => array(
+                    'label' => __( 'Hotel type', 'lbhotel' ),
+                ),
+            ),
+            'details'    => array(
+                'vm_room_types' => array(
+                    'label'     => __( 'Room types', 'lbhotel' ),
+                    'multiline' => true,
+                ),
+            ),
+            'actions'    => array(
+                array(
+                    'meta'  => 'vm_booking_url',
+                    'label' => __( 'Book now', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--primary',
+                ),
+            ),
+        ),
+        'restaurants' => array(
+            'highlights' => array(
+                'vm_specialties' => array(
+                    'label'     => __( 'Specialties', 'lbhotel' ),
+                    'multiline' => true,
+                ),
+            ),
+            'details'    => array(
+                'vm_opening_hours' => array(
+                    'label'     => __( 'Opening hours', 'lbhotel' ),
+                    'multiline' => true,
+                ),
+            ),
+            'actions'    => array(
+                array(
+                    'meta'  => 'vm_menu_url',
+                    'label' => __( 'View menu', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--primary',
+                ),
+            ),
+            'secondary_actions' => array(
+                array(
+                    'meta'  => 'vm_booking_url',
+                    'label' => __( 'Reserve', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--ghost',
+                ),
+            ),
+        ),
+        'cultural-events' => array(
+            'highlights' => array(
+                'vm_event_type' => array(
+                    'label' => __( 'Event type', 'lbhotel' ),
+                ),
+            ),
+            'details'    => array(
+                'vm_event_datetime' => array(
+                    'label' => __( 'Event date & time', 'lbhotel' ),
+                ),
+            ),
+            'actions'    => array(
+                array(
+                    'meta'  => 'vm_ticket_url',
+                    'label' => __( 'Buy tickets', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--primary',
+                ),
+            ),
+            'secondary_actions' => array(
+                array(
+                    'meta'  => 'vm_ticket_info_url',
+                    'label' => __( 'Ticket information', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--ghost',
+                ),
+            ),
+        ),
+        'recreational-activities' => array(
+            'highlights' => array(
+                'vm_activity_type' => array(
+                    'label' => __( 'Activity type', 'lbhotel' ),
+                ),
+            ),
+            'details'    => array(
+                'vm_seasonality' => array(
+                    'label' => __( 'Seasonality', 'lbhotel' ),
+                ),
+            ),
+            'actions'    => array(
+                array(
+                    'meta'  => 'vm_booking_url',
+                    'label' => __( 'Book activity', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--primary',
+                ),
+            ),
+        ),
+        'shopping' => array(
+            'highlights' => array(
+                'vm_product_categories' => array(
+                    'label'     => __( 'Product categories', 'lbhotel' ),
+                    'multiline' => true,
+                ),
+            ),
+            'actions'    => array(
+                array(
+                    'meta'  => 'vm_sales_url',
+                    'label' => __( 'View promotions', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--primary',
+                ),
+            ),
+        ),
+        'sports-activities' => array(
+            'highlights' => array(
+                'vm_sport_type' => array(
+                    'label' => __( 'Sport type', 'lbhotel' ),
+                ),
+            ),
+            'actions'    => array(
+                array(
+                    'meta'  => 'vm_equipment_rental_url',
+                    'label' => __( 'Rent equipment', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--primary',
+                ),
+            ),
+            'secondary_actions' => array(
+                array(
+                    'meta'  => 'vm_booking_url',
+                    'label' => __( 'Book session', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--ghost',
+                ),
+            ),
+        ),
+        'tourist-sites' => array(
+            'highlights' => array(
+                'vm_opening_hours' => array(
+                    'label'     => __( 'Opening hours', 'lbhotel' ),
+                    'multiline' => true,
+                ),
+            ),
+            'actions'    => array(
+                array(
+                    'meta'  => 'vm_ticket_info_url',
+                    'label' => __( 'Ticket information', 'lbhotel' ),
+                    'class' => 'lbhotel-button lbhotel-button--primary',
+                ),
+            ),
+        ),
+    );
 }

--- a/single-hotel.css
+++ b/single-hotel.css
@@ -1,0 +1,314 @@
+:root {
+    --lbhotel-primary: #c1272d;
+    --lbhotel-secondary: #006233;
+    --lbhotel-cream: #f8f3eb;
+    --lbhotel-text: #2c2c2c;
+    --lbhotel-muted: #6a6a6a;
+}
+
+.lbhotel-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 1.5rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    border: none;
+    cursor: pointer;
+}
+
+.lbhotel-button:hover,
+.lbhotel-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
+}
+
+.lbhotel-button--primary {
+    background: var(--lbhotel-primary);
+    color: #fff;
+}
+
+.lbhotel-button--ghost {
+    background: transparent;
+    border: 1px solid currentColor;
+    color: var(--lbhotel-primary);
+}
+
+.lbhotel-single-place {
+    margin: 0 auto 4rem;
+    max-width: 1200px;
+    color: var(--lbhotel-text);
+}
+
+.lbhotel-single-place__header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.lbhotel-single-place__category-label {
+    display: inline-block;
+    background: var(--lbhotel-secondary);
+    color: #fff;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.8rem;
+}
+
+.lbhotel-single-place__title {
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    margin: 0.2rem 0;
+}
+
+.lbhotel-single-place__categories {
+    color: var(--lbhotel-muted);
+    font-style: italic;
+    margin: 0;
+}
+
+.lbhotel-single-place__layout {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    background: var(--lbhotel-cream);
+    padding: 2rem;
+    border-radius: 24px;
+    box-shadow: 0 25px 40px rgba(0, 0, 0, 0.12);
+}
+
+.lbhotel-single-place__hero {
+    background: #fff;
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    gap: 1.5rem;
+    padding: 1.5rem;
+    align-items: center;
+}
+
+.lbhotel-single-place__media {
+    position: relative;
+    overflow: hidden;
+    border-radius: 14px;
+    background: rgba(0, 0, 0, 0.05);
+    min-height: 260px;
+}
+
+.lbhotel-single-place__slides {
+    display: flex;
+    transition: transform 0.5s ease;
+    width: 100%;
+    height: 100%;
+}
+
+.lbhotel-single-place__slide {
+    flex: 0 0 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lbhotel-single-place__slide img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.lbhotel-single-place__nav {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    border: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.lbhotel-single-place__nav--prev {
+    left: 1rem;
+}
+
+.lbhotel-single-place__nav--next {
+    right: 1rem;
+}
+
+.lbhotel-single-place__nav:hover,
+.lbhotel-single-place__nav:focus-visible {
+    background: var(--lbhotel-primary);
+}
+
+.lbhotel-single-place__dots {
+    position: absolute;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 0.5rem;
+}
+
+.lbhotel-single-place__dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(255, 255, 255, 0.6);
+    cursor: pointer;
+}
+
+.lbhotel-single-place__dot.is-active,
+.lbhotel-single-place__dot:hover,
+.lbhotel-single-place__dot:focus-visible {
+    background: var(--lbhotel-primary);
+}
+
+.lbhotel-single-place__placeholder {
+    width: 100%;
+    height: 100%;
+    background: repeating-linear-gradient(45deg, rgba(0,0,0,0.05), rgba(0,0,0,0.05) 20px, rgba(0,0,0,0.1) 20px, rgba(0,0,0,0.1) 40px);
+}
+
+.lbhotel-single-place__info {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.lbhotel-single-place__rating {
+    display: flex;
+    align-items: center;
+}
+
+.lbhotel-rating {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 600;
+    color: var(--lbhotel-primary);
+}
+
+.lbhotel-rating__stars {
+    display: inline-flex;
+    gap: 0.1rem;
+    font-size: 1.1rem;
+}
+
+.lbhotel-rating__star.is-empty {
+    color: rgba(0, 0, 0, 0.2);
+}
+
+.lbhotel-rating__value {
+    font-size: 0.9rem;
+    color: var(--lbhotel-muted);
+}
+
+.lbhotel-single-place__location {
+    margin: 0;
+    color: var(--lbhotel-muted);
+    font-size: 1rem;
+}
+
+.lbhotel-single-place__highlights {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.6rem;
+}
+
+.lbhotel-single-place__highlights li {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.lbhotel-single-place__highlight-label {
+    font-weight: 600;
+    color: var(--lbhotel-secondary);
+}
+
+.lbhotel-single-place__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.lbhotel-single-place__main-content {
+    background: #fff;
+    padding: 1.75rem;
+    border-radius: 18px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.lbhotel-single-place__description > *:first-child {
+    margin-top: 0;
+}
+
+.lbhotel-single-place__sidebar {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.lbhotel-single-place__panel {
+    background: #fff;
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+}
+
+.lbhotel-single-place__panel h2 {
+    margin-top: 0;
+    font-size: 1.1rem;
+}
+
+.lbhotel-single-place__list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    display: grid;
+    gap: 0.35rem;
+    color: var(--lbhotel-muted);
+}
+
+.lbhotel-single-place__details {
+    margin: 0;
+}
+
+.lbhotel-single-place__details dt {
+    font-weight: 600;
+    margin-top: 0.75rem;
+}
+
+.lbhotel-single-place__details dt:first-of-type {
+    margin-top: 0;
+}
+
+.lbhotel-single-place__details dd {
+    margin: 0.25rem 0 0;
+    color: var(--lbhotel-muted);
+}
+
+.lbhotel-single-place__contact {
+    font-weight: 600;
+    color: var(--lbhotel-primary);
+}
+
+@media (max-width: 900px) {
+    .lbhotel-single-place__hero {
+        grid-template-columns: 1fr;
+    }
+
+    .lbhotel-single-place__layout {
+        padding: 1.5rem;
+    }
+}

--- a/single-hotel.js
+++ b/single-hotel.js
@@ -1,0 +1,70 @@
+(function () {
+    const sliders = document.querySelectorAll('[data-lbhotel-slider]');
+
+    sliders.forEach((slider) => {
+        if (slider.dataset.lbhotelSliderInitialised) {
+            return;
+        }
+
+        const track = slider.querySelector('.lbhotel-single-place__slides');
+        const slides = track ? Array.from(track.children) : [];
+        const prev = slider.querySelector('.lbhotel-single-place__nav--prev');
+        const next = slider.querySelector('.lbhotel-single-place__nav--next');
+        const dots = Array.from(slider.querySelectorAll('.lbhotel-single-place__dot'));
+        let index = 0;
+
+        if (!track || slides.length === 0) {
+            slider.dataset.lbhotelSliderInitialised = 'true';
+            return;
+        }
+
+        const update = () => {
+            track.style.transform = `translateX(-${index * 100}%)`;
+            dots.forEach((dot, dotIndex) => {
+                dot.classList.toggle('is-active', dotIndex === index);
+            });
+        };
+
+        const goTo = (nextIndex) => {
+            index = (nextIndex + slides.length) % slides.length;
+            update();
+        };
+
+        const handleActivation = (event, callback) => {
+            if (typeof callback !== 'function') {
+                return;
+            }
+
+            if (event.type === 'click') {
+                event.preventDefault();
+                callback();
+            } else if (event.type === 'keydown') {
+                if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+                    event.preventDefault();
+                    callback();
+                }
+            }
+        };
+
+        if (prev) {
+            ['click', 'keydown'].forEach((type) => {
+                prev.addEventListener(type, (event) => handleActivation(event, () => goTo(index - 1)));
+            });
+        }
+
+        if (next) {
+            ['click', 'keydown'].forEach((type) => {
+                next.addEventListener(type, (event) => handleActivation(event, () => goTo(index + 1)));
+            });
+        }
+
+        dots.forEach((dot, dotIndex) => {
+            ['click', 'keydown'].forEach((type) => {
+                dot.addEventListener(type, (event) => handleActivation(event, () => goTo(dotIndex)));
+            });
+        });
+
+        slider.dataset.lbhotelSliderInitialised = 'true';
+        update();
+    });
+})();

--- a/templates/shared/all-places.php
+++ b/templates/shared/all-places.php
@@ -23,12 +23,26 @@ if ( ! $context || 'archive' !== $context['type'] ) {
 
 $category_slug    = $context['category'];
 $category_labels  = lbhotel_get_place_category_labels();
+$category_config  = lbhotel_get_category_display_config();
+$category_display = isset( $category_config[ $category_slug ] ) ? $category_config[ $category_slug ] : array();
 $descriptions     = lbhotel_get_place_category_descriptions();
 $default_title    = isset( $category_labels[ $category_slug ] ) ? $category_labels[ $category_slug ] : post_type_archive_title( '', false );
 $default_message  = __( 'Browse immersive experiences and essential details for destinations across Morocco.', 'lbhotel' );
 $archive_title    = $default_title;
 $archive_intro    = $default_message;
 $category_term    = is_tax( 'lbhotel_place_category' ) ? get_queried_object() : null;
+$global_secondary = array(
+    array(
+        'meta'  => 'vm_virtual_tour_url',
+        'label' => __( 'Virtual tour', 'lbhotel' ),
+        'class' => 'lbhotel-button lbhotel-button--ghost',
+    ),
+    array(
+        'meta'  => 'vm_google_map_url',
+        'label' => __( 'Map', 'lbhotel' ),
+        'class' => 'lbhotel-button lbhotel-button--ghost',
+    ),
+);
 
 if ( $category_term instanceof WP_Term ) {
     $archive_title = $category_term->name;
@@ -67,289 +81,139 @@ $paged = max(
                 while ( have_posts() ) :
                     the_post();
 
-                    $post_id      = get_the_ID();
-                    $city         = get_post_meta( $post_id, 'lbhotel_city', true );
-                    $region       = get_post_meta( $post_id, 'lbhotel_region', true );
-                    $country      = get_post_meta( $post_id, 'lbhotel_country', true );
-                    $virtual_tour = get_post_meta( $post_id, 'lbhotel_virtual_tour_url', true );
-                    $google_maps  = get_post_meta( $post_id, 'lbhotel_google_maps_url', true );
-                    $contact      = get_post_meta( $post_id, 'lbhotel_contact_phone', true );
-                    $categories   = wp_get_post_terms( $post_id, 'lbhotel_place_category' );
+                    $post_id  = get_the_ID();
+                    $city     = lbhotel_get_meta_with_fallback( $post_id, 'vm_city', '' );
+                    $region   = lbhotel_get_meta_with_fallback( $post_id, 'vm_region', '' );
+                    $country  = lbhotel_get_meta_with_fallback( $post_id, 'vm_country', '' );
+                    $contact  = lbhotel_get_meta_with_fallback( $post_id, 'vm_contact_phone', '' );
+                    $rating   = lbhotel_get_rating_value( $post_id );
 
-                    $category_actions   = array();
-                    $category_highlight = array();
+                    $image_url = get_the_post_thumbnail_url( $post_id, 'large' );
+                    $excerpt   = get_the_excerpt();
+                    $location  = implode( ', ', array_filter( array( $city, $region, $country ) ) );
 
-                    foreach ( $categories as $category ) {
-                        switch ( $category->slug ) {
-                            case 'hotels':
-                                $booking_url = get_post_meta( $post_id, 'lbhotel_booking_url', true );
-                                if ( $booking_url ) {
-                                    $category_actions['booking'] = array(
-                                        'label' => __( 'Book now', 'lbhotel' ),
-                                        'url'   => $booking_url,
-                                        'class' => 'button',
-                                    );
-                                }
+                    $highlights = array();
+                    if ( ! empty( $category_display['highlights'] ) && is_array( $category_display['highlights'] ) ) {
+                        foreach ( $category_display['highlights'] as $meta_key => $definition ) {
+                            $value = lbhotel_get_meta_with_fallback( $post_id, $meta_key, '' );
 
-                                $price_range = get_post_meta( $post_id, 'lbhotel_price_range', true );
-                                if ( $price_range ) {
-                                    $category_highlight['price'] = array(
-                                        'label' => __( 'Price range', 'lbhotel' ),
-                                        'value' => $price_range,
-                                    );
-                                }
+                            if ( '' === $value ) {
+                                continue;
+                            }
 
-                                $room_types = get_post_meta( $post_id, 'lbhotel_room_types', true );
-                                if ( $room_types ) {
-                                    $category_highlight['room_types'] = array(
-                                        'label'     => __( 'Room types', 'lbhotel' ),
-                                        'value'     => $room_types,
-                                        'multiline' => true,
-                                    );
-                                }
-                                break;
-                            case 'restaurants':
-                                $menu_url = get_post_meta( $post_id, 'lbhotel_menu_url', true );
-                                if ( $menu_url ) {
-                                    $category_actions['menu'] = array(
-                                        'label' => __( 'View menu', 'lbhotel' ),
-                                        'url'   => $menu_url,
-                                        'class' => 'button',
-                                    );
-                                }
-
-                                $reservation_url = get_post_meta( $post_id, 'lbhotel_reservation_url', true );
-                                if ( $reservation_url ) {
-                                    if ( filter_var( $reservation_url, FILTER_VALIDATE_URL ) ) {
-                                        $category_actions['reservation'] = array(
-                                            'label' => __( 'Reserve a table', 'lbhotel' ),
-                                            'url'   => $reservation_url,
-                                            'class' => 'button button-secondary',
-                                        );
-                                    } else {
-                                        $category_highlight['reservation'] = array(
-                                            'label' => __( 'Reservations', 'lbhotel' ),
-                                            'value' => $reservation_url,
-                                        );
-                                    }
-                                }
-
-                                $opening_hours = get_post_meta( $post_id, 'lbhotel_opening_hours', true );
-                                if ( $opening_hours ) {
-                                    $category_highlight['opening_hours'] = array(
-                                        'label'     => __( 'Opening hours', 'lbhotel' ),
-                                        'value'     => $opening_hours,
-                                        'multiline' => true,
-                                    );
-                                }
-
-                                $specialties = get_post_meta( $post_id, 'lbhotel_specialties', true );
-                                if ( $specialties ) {
-                                    $category_highlight['specialties'] = array(
-                                        'label'     => __( 'Specialties', 'lbhotel' ),
-                                        'value'     => $specialties,
-                                        'multiline' => true,
-                                    );
-                                }
-                                break;
-                            case 'tourist-sites':
-                                $opening_hours = get_post_meta( $post_id, 'lbhotel_opening_hours', true );
-                                if ( $opening_hours ) {
-                                    $category_highlight['opening_hours'] = array(
-                                        'label'     => __( 'Opening hours', 'lbhotel' ),
-                                        'value'     => $opening_hours,
-                                        'multiline' => true,
-                                    );
-                                }
-
-                                $ticket_price_url = get_post_meta( $post_id, 'lbhotel_ticket_price_url', true );
-                                if ( $ticket_price_url ) {
-                                    $category_actions['ticket_price'] = array(
-                                        'label' => __( 'Ticket pricing', 'lbhotel' ),
-                                        'url'   => $ticket_price_url,
-                                        'class' => 'button',
-                                    );
-                                }
-
-                                $event_schedule_url = get_post_meta( $post_id, 'lbhotel_event_schedule_url', true );
-                                if ( $event_schedule_url ) {
-                                    $category_actions['event_schedule'] = array(
-                                        'label' => __( 'Event schedule', 'lbhotel' ),
-                                        'url'   => $event_schedule_url,
-                                        'class' => 'button button-secondary',
-                                    );
-                                }
-                                break;
-                            case 'recreational-activities':
-                                $activity_type = get_post_meta( $post_id, 'lbhotel_activity_type', true );
-                                if ( $activity_type ) {
-                                    $category_highlight['activity_type'] = array(
-                                        'label' => __( 'Activity type', 'lbhotel' ),
-                                        'value' => $activity_type,
-                                    );
-                                }
-
-                                $booking_url = get_post_meta( $post_id, 'lbhotel_booking_url', true );
-                                if ( $booking_url ) {
-                                    $category_actions['activity_booking'] = array(
-                                        'label' => __( 'Book activity', 'lbhotel' ),
-                                        'url'   => $booking_url,
-                                        'class' => 'button',
-                                    );
-                                }
-
-                                $seasonality = get_post_meta( $post_id, 'lbhotel_seasonality', true );
-                                if ( $seasonality ) {
-                                    $category_highlight['seasonality'] = array(
-                                        'label' => __( 'Seasonality', 'lbhotel' ),
-                                        'value' => $seasonality,
-                                    );
-                                }
-                                break;
-                            case 'shopping':
-                                $sales_url = get_post_meta( $post_id, 'lbhotel_sales_url', true );
-                                if ( $sales_url ) {
-                                    $category_actions['sales'] = array(
-                                        'label' => __( 'View promotions', 'lbhotel' ),
-                                        'url'   => $sales_url,
-                                        'class' => 'button',
-                                    );
-                                }
-
-                                $product_categories = get_post_meta( $post_id, 'lbhotel_product_categories', true );
-                                if ( $product_categories ) {
-                                    $category_highlight['products'] = array(
-                                        'label'     => __( 'Product categories', 'lbhotel' ),
-                                        'value'     => $product_categories,
-                                        'multiline' => true,
-                                    );
-                                }
-
-                                $store_type = get_post_meta( $post_id, 'lbhotel_store_type', true );
-                                if ( $store_type ) {
-                                    $category_highlight['store_type'] = array(
-                                        'label' => __( 'Store type', 'lbhotel' ),
-                                        'value' => $store_type,
-                                    );
-                                }
-                                break;
-                            case 'sports-activities':
-                                $sport_type = get_post_meta( $post_id, 'lbhotel_sport_type', true );
-                                if ( $sport_type ) {
-                                    $category_highlight['sport_type'] = array(
-                                        'label' => __( 'Sport type', 'lbhotel' ),
-                                        'value' => $sport_type,
-                                    );
-                                }
-
-                                $equipment_url = get_post_meta( $post_id, 'lbhotel_equipment_rental_url', true );
-                                if ( $equipment_url ) {
-                                    $category_actions['equipment'] = array(
-                                        'label' => __( 'Rent equipment', 'lbhotel' ),
-                                        'url'   => $equipment_url,
-                                        'class' => 'button',
-                                    );
-                                }
-
-                                $training_schedule_url = get_post_meta( $post_id, 'lbhotel_training_schedule_url', true );
-                                if ( $training_schedule_url ) {
-                                    $category_actions['training_schedule_url'] = array(
-                                        'label' => __( 'Training schedule', 'lbhotel' ),
-                                        'url'   => $training_schedule_url,
-                                        'class' => 'button button-secondary',
-                                    );
-                                }
-
-                                $training_schedule = get_post_meta( $post_id, 'lbhotel_training_schedule', true );
-                                if ( $training_schedule ) {
-                                    $category_highlight['training_schedule'] = array(
-                                        'label'     => __( 'Training details', 'lbhotel' ),
-                                        'value'     => $training_schedule,
-                                        'multiline' => true,
-                                    );
-                                }
-                                break;
-                            case 'cultural-events':
-                                $event_date_time = get_post_meta( $post_id, 'lbhotel_event_date_time', true );
-                                if ( $event_date_time ) {
-                                    $timestamp = strtotime( $event_date_time );
-                                    if ( $timestamp ) {
-                                        $formatted = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
-                                    } else {
-                                        $formatted = $event_date_time;
-                                    }
-
-                                    $category_highlight['event_date_time'] = array(
-                                        'label' => __( 'Event date & time', 'lbhotel' ),
-                                        'value' => $formatted,
-                                    );
-                                }
-
-                                $event_type = get_post_meta( $post_id, 'lbhotel_event_type', true );
-                                if ( $event_type ) {
-                                    $category_highlight['event_type'] = array(
-                                        'label' => __( 'Event type', 'lbhotel' ),
-                                        'value' => $event_type,
-                                    );
-                                }
-
-                                $ticket_url = get_post_meta( $post_id, 'lbhotel_ticket_url', true );
-                                if ( $ticket_url ) {
-                                    $category_actions['ticket_url'] = array(
-                                        'label' => __( 'Buy tickets', 'lbhotel' ),
-                                        'url'   => $ticket_url,
-                                        'class' => 'button',
-                                    );
-                                }
-
-                                $ticket_price_url = get_post_meta( $post_id, 'lbhotel_ticket_price_url', true );
-                                if ( $ticket_price_url ) {
-                                    $category_actions['ticket_price'] = array(
-                                        'label' => __( 'Ticket pricing', 'lbhotel' ),
-                                        'url'   => $ticket_price_url,
-                                        'class' => 'button button-secondary',
-                                    );
-                                }
-
-                                $event_schedule_url = get_post_meta( $post_id, 'lbhotel_event_schedule_url', true );
-                                if ( $event_schedule_url ) {
-                                    $category_actions['event_schedule'] = array(
-                                        'label' => __( 'Event schedule', 'lbhotel' ),
-                                        'url'   => $event_schedule_url,
-                                        'class' => 'button button-secondary',
-                                    );
-                                }
-                                break;
+                            $highlights[] = array(
+                                'label'     => isset( $definition['label'] ) ? $definition['label'] : '',
+                                'value'     => $value,
+                                'multiline' => ! empty( $definition['multiline'] ),
+                            );
                         }
                     }
+
+                    if ( empty( $highlights ) && ! empty( $category_display['details'] ) ) {
+                        foreach ( $category_display['details'] as $meta_key => $definition ) {
+                            $value = lbhotel_get_meta_with_fallback( $post_id, $meta_key, '' );
+
+                            if ( '' === $value ) {
+                                continue;
+                            }
+
+                            if ( 'vm_event_datetime' === $meta_key ) {
+                                $timestamp = strtotime( $value );
+                                if ( $timestamp ) {
+                                    $value = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+                                }
+                            }
+
+                            $highlights[] = array(
+                                'label'     => isset( $definition['label'] ) ? $definition['label'] : '',
+                                'value'     => $value,
+                                'multiline' => ! empty( $definition['multiline'] ),
+                            );
+                        }
+                    }
+
+                    $primary_buttons   = array();
+                    $secondary_buttons = array();
+
+                    if ( ! empty( $category_display['actions'] ) ) {
+                        foreach ( $category_display['actions'] as $action ) {
+                            if ( empty( $action['meta'] ) ) {
+                                continue;
+                            }
+
+                            $url = lbhotel_get_meta_with_fallback( $post_id, $action['meta'], '' );
+                            if ( ! $url ) {
+                                continue;
+                            }
+
+                            $primary_buttons[] = array(
+                                'url'   => esc_url( $url ),
+                                'label' => isset( $action['label'] ) ? $action['label'] : __( 'Learn more', 'lbhotel' ),
+                                'class' => isset( $action['class'] ) ? $action['class'] : 'lbhotel-button',
+                            );
+                        }
+                    }
+
+                    $configured_secondary = array();
+                    if ( ! empty( $category_display['secondary_actions'] ) ) {
+                        $configured_secondary = (array) $category_display['secondary_actions'];
+                    }
+
+                    foreach ( array_merge( $configured_secondary, $global_secondary ) as $action ) {
+                        if ( empty( $action['meta'] ) ) {
+                            continue;
+                        }
+
+                        $value = lbhotel_get_meta_with_fallback( $post_id, $action['meta'], '' );
+                        if ( ! $value ) {
+                            continue;
+                        }
+
+                        $secondary_buttons[] = array(
+                            'url'   => esc_url( $value ),
+                            'label' => isset( $action['label'] ) ? $action['label'] : __( 'View', 'lbhotel' ),
+                            'class' => isset( $action['class'] ) ? $action['class'] : 'lbhotel-button lbhotel-button--ghost',
+                        );
+                    }
+
+                    $rating_markup = lbhotel_get_rating_markup( $rating, array(
+                        'show_value' => false,
+                        'class'      => 'lbhotel-rating lbhotel-rating--compact',
+                    ) );
                     ?>
                     <article <?php post_class( 'lbhotel-archive__item' ); ?>>
                         <a class="lbhotel-archive__thumbnail" href="<?php the_permalink(); ?>">
-                            <?php if ( has_post_thumbnail() ) : ?>
-                                <?php the_post_thumbnail( 'medium_large' ); ?>
+                            <?php if ( $image_url ) : ?>
+                                <span class="lbhotel-archive__thumb" style="background-image: url(<?php echo esc_url( $image_url ); ?>);"></span>
+                                <span class="screen-reader-text"><?php the_title(); ?></span>
                             <?php else : ?>
-                                <div class="lbhotel-archive__placeholder" aria-hidden="true"></div>
+                                <span class="lbhotel-archive__placeholder" aria-hidden="true"></span>
                             <?php endif; ?>
                         </a>
                         <div class="lbhotel-archive__body">
                             <h2 class="lbhotel-archive__name"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-                            <?php if ( ! empty( $categories ) ) : ?>
-                                <p class="lbhotel-archive__categories"><?php echo esc_html( implode( ', ', wp_list_pluck( $categories, 'name' ) ) ); ?></p>
+
+                            <?php if ( $rating_markup ) : ?>
+                                <div class="lbhotel-archive__rating">
+                                    <?php echo $rating_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                </div>
                             <?php endif; ?>
 
-                            <?php if ( $city || $region || $country ) : ?>
-                                <p class="lbhotel-archive__location">
-                                    <?php echo esc_html( trim( implode( ', ', array_filter( array( $city, $region, $country ) ) ) ) ); ?>
-                                </p>
+                            <?php if ( $location ) : ?>
+                                <p class="lbhotel-archive__location"><?php echo esc_html( $location ); ?></p>
                             <?php endif; ?>
 
-                            <div class="lbhotel-archive__excerpt"><?php the_excerpt(); ?></div>
+                            <?php if ( $excerpt ) : ?>
+                                <p class="lbhotel-archive__excerpt"><?php echo esc_html( wp_trim_words( $excerpt, 30 ) ); ?></p>
+                            <?php endif; ?>
 
-                            <?php if ( ! empty( $category_highlight ) ) : ?>
+                            <?php if ( ! empty( $highlights ) ) : ?>
                                 <ul class="lbhotel-archive__highlights">
-                                    <?php foreach ( $category_highlight as $highlight ) : ?>
+                                    <?php foreach ( $highlights as $highlight ) : ?>
                                         <li>
-                                            <span class="lbhotel-archive__highlight-label"><?php echo esc_html( $highlight['label'] ); ?>:</span>
+                                            <?php if ( $highlight['label'] ) : ?>
+                                                <span class="lbhotel-archive__highlight-label"><?php echo esc_html( $highlight['label'] ); ?>:</span>
+                                            <?php endif; ?>
                                             <span class="lbhotel-archive__highlight-value">
                                                 <?php
                                                 if ( ! empty( $highlight['multiline'] ) ) {
@@ -365,33 +229,17 @@ $paged = max(
                             <?php endif; ?>
 
                             <div class="lbhotel-archive__actions">
-                                <a class="button" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View details', 'lbhotel' ); ?></a>
-                                <?php
-                                foreach ( $category_actions as $action ) {
-                                    printf(
-                                        '<a class="%1$s" href="%2$s" target="_blank" rel="noopener">%3$s</a>',
-                                        esc_attr( $action['class'] ),
-                                        esc_url( $action['url'] ),
-                                        esc_html( $action['label'] )
-                                    );
-                                }
-
-                                if ( $virtual_tour ) {
-                                    printf(
-                                        '<a class="button button-secondary" href="%1$s" target="_blank" rel="noopener">%2$s</a>',
-                                        esc_url( $virtual_tour ),
-                                        esc_html__( 'Virtual tour', 'lbhotel' )
-                                    );
-                                }
-
-                                if ( $google_maps ) {
-                                    printf(
-                                        '<a class="button button-secondary" href="%1$s" target="_blank" rel="noopener">%2$s</a>',
-                                        esc_url( $google_maps ),
-                                        esc_html__( 'Map', 'lbhotel' )
-                                    );
-                                }
-                                ?>
+                                <a class="lbhotel-button lbhotel-button--primary" href="<?php the_permalink(); ?>"><?php esc_html_e( 'View details', 'lbhotel' ); ?></a>
+                                <?php foreach ( $primary_buttons as $button ) : ?>
+                                    <a class="<?php echo esc_attr( $button['class'] ); ?>" href="<?php echo esc_url( $button['url'] ); ?>" target="_blank" rel="noopener">
+                                        <?php echo esc_html( $button['label'] ); ?>
+                                    </a>
+                                <?php endforeach; ?>
+                                <?php foreach ( $secondary_buttons as $button ) : ?>
+                                    <a class="<?php echo esc_attr( $button['class'] ); ?>" href="<?php echo esc_url( $button['url'] ); ?>" target="_blank" rel="noopener">
+                                        <?php echo esc_html( $button['label'] ); ?>
+                                    </a>
+                                <?php endforeach; ?>
                             </div>
 
                             <?php if ( $contact ) : ?>

--- a/templates/shared/single-place.php
+++ b/templates/shared/single-place.php
@@ -19,10 +19,24 @@ if ( ! $context || 'single' !== $context['type'] ) {
     );
 }
 
-$category_slug   = $context['category'];
-$category_labels = lbhotel_get_place_category_labels();
-$active_label    = isset( $category_labels[ $category_slug ] ) ? $category_labels[ $category_slug ] : '';
-$category_class  = 'lbhotel-single-place--' . sanitize_html_class( $category_slug );
+$category_slug        = $context['category'];
+$category_labels      = lbhotel_get_place_category_labels();
+$display_config_map   = lbhotel_get_category_display_config();
+$active_label         = isset( $category_labels[ $category_slug ] ) ? $category_labels[ $category_slug ] : '';
+$category_class       = 'lbhotel-single-place--' . sanitize_html_class( $category_slug );
+$category_display     = isset( $display_config_map[ $category_slug ] ) ? $display_config_map[ $category_slug ] : array();
+$global_secondary_map = array(
+    array(
+        'meta'  => 'vm_virtual_tour_url',
+        'label' => __( 'Virtual tour', 'lbhotel' ),
+        'class' => 'lbhotel-button lbhotel-button--ghost',
+    ),
+    array(
+        'meta'  => 'vm_google_map_url',
+        'label' => __( 'Map', 'lbhotel' ),
+        'class' => 'lbhotel-button lbhotel-button--ghost',
+    ),
+);
 
 get_header();
 
@@ -37,21 +51,142 @@ while ( have_posts() ) :
         $category_map[ $term->slug ] = $term->name;
     }
 
-    $location_meta = array(
-        'lbhotel_address'         => get_post_meta( $post_id, 'lbhotel_address', true ),
-        'lbhotel_city'            => get_post_meta( $post_id, 'lbhotel_city', true ),
-        'lbhotel_region'          => get_post_meta( $post_id, 'lbhotel_region', true ),
-        'lbhotel_postal_code'     => get_post_meta( $post_id, 'lbhotel_postal_code', true ),
-        'lbhotel_country'         => get_post_meta( $post_id, 'lbhotel_country', true ),
-        'lbhotel_google_maps_url' => get_post_meta( $post_id, 'lbhotel_google_maps_url', true ),
-        'lbhotel_latitude'        => get_post_meta( $post_id, 'lbhotel_latitude', true ),
-        'lbhotel_longitude'       => get_post_meta( $post_id, 'lbhotel_longitude', true ),
-    );
+    $address     = lbhotel_get_meta_with_fallback( $post_id, 'vm_street_address', '' );
+    $city        = lbhotel_get_meta_with_fallback( $post_id, 'vm_city', '' );
+    $region      = lbhotel_get_meta_with_fallback( $post_id, 'vm_region', '' );
+    $postal_code = lbhotel_get_meta_with_fallback( $post_id, 'vm_postal_code', '' );
+    $country     = lbhotel_get_meta_with_fallback( $post_id, 'vm_country', '' );
+    $latitude    = lbhotel_get_meta_with_fallback( $post_id, 'vm_latitude', '' );
+    $longitude   = lbhotel_get_meta_with_fallback( $post_id, 'vm_longitude', '' );
 
-    $contact_phone    = get_post_meta( $post_id, 'lbhotel_contact_phone', true );
-    $virtual_tour_url = get_post_meta( $post_id, 'lbhotel_virtual_tour_url', true );
+    $virtual_tour_url = lbhotel_get_meta_with_fallback( $post_id, 'vm_virtual_tour_url', '' );
+    $map_url          = lbhotel_get_meta_with_fallback( $post_id, 'vm_google_map_url', '' );
 
-    $gallery = lbhotel_sanitize_gallery_images( get_post_meta( $post_id, 'lbhotel_gallery_images', true ) );
+    if ( ! $map_url && $latitude && $longitude ) {
+        $map_url = sprintf( 'https://www.google.com/maps/search/?api=1&query=%s', rawurlencode( $latitude . ',' . $longitude ) );
+    }
+
+    $contact_phone = lbhotel_get_meta_with_fallback( $post_id, 'vm_contact_phone', '' );
+
+    $gallery_ids = lbhotel_sanitize_gallery_images( get_post_meta( $post_id, 'lbhotel_gallery_images', true ) );
+
+    if ( empty( $gallery_ids ) ) {
+        $vm_gallery = get_post_meta( $post_id, 'vm_gallery', true );
+
+        if ( is_array( $vm_gallery ) ) {
+            $gallery_ids = array_filter( array_map( 'absint', $vm_gallery ) );
+        }
+    }
+
+    $gallery_urls = array();
+
+    foreach ( $gallery_ids as $attachment_id ) {
+        $image_url = wp_get_attachment_image_url( $attachment_id, 'large' );
+        if ( $image_url ) {
+            $gallery_urls[] = $image_url;
+        }
+    }
+
+    if ( empty( $gallery_urls ) && has_post_thumbnail( $post_id ) ) {
+        $featured_url = get_the_post_thumbnail_url( $post_id, 'large' );
+        if ( $featured_url ) {
+            $gallery_urls[] = $featured_url;
+        }
+    }
+
+    $rating_value  = lbhotel_get_rating_value( $post_id );
+    $rating_markup = lbhotel_get_rating_markup( $rating_value );
+
+    $highlights = array();
+    if ( ! empty( $category_display['highlights'] ) && is_array( $category_display['highlights'] ) ) {
+        foreach ( $category_display['highlights'] as $meta_key => $definition ) {
+            $value = lbhotel_get_meta_with_fallback( $post_id, $meta_key, '' );
+
+            if ( '' === $value ) {
+                continue;
+            }
+
+            $highlights[] = array(
+                'label'     => isset( $definition['label'] ) ? $definition['label'] : '',
+                'value'     => $value,
+                'multiline' => ! empty( $definition['multiline'] ),
+            );
+        }
+    }
+
+    $details = array();
+    if ( ! empty( $category_display['details'] ) && is_array( $category_display['details'] ) ) {
+        foreach ( $category_display['details'] as $meta_key => $definition ) {
+            $value = lbhotel_get_meta_with_fallback( $post_id, $meta_key, '' );
+
+            if ( '' === $value ) {
+                continue;
+            }
+
+            if ( 'vm_event_datetime' === $meta_key ) {
+                $timestamp = strtotime( $value );
+                if ( $timestamp ) {
+                    $value = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+                }
+            }
+
+            $details[] = array(
+                'label'     => isset( $definition['label'] ) ? $definition['label'] : '',
+                'value'     => $value,
+                'multiline' => ! empty( $definition['multiline'] ),
+            );
+        }
+    }
+
+    $primary_buttons   = array();
+    $secondary_buttons = array();
+
+    if ( ! empty( $category_display['actions'] ) ) {
+        foreach ( $category_display['actions'] as $action ) {
+            if ( empty( $action['meta'] ) ) {
+                continue;
+            }
+
+            $url = lbhotel_get_meta_with_fallback( $post_id, $action['meta'], '' );
+
+            if ( ! $url ) {
+                continue;
+            }
+
+            $primary_buttons[] = array(
+                'url'   => esc_url( $url ),
+                'label' => isset( $action['label'] ) ? $action['label'] : __( 'Learn more', 'lbhotel' ),
+                'class' => isset( $action['class'] ) ? $action['class'] : 'lbhotel-button',
+            );
+        }
+    }
+
+    $configured_secondary = array();
+    if ( ! empty( $category_display['secondary_actions'] ) ) {
+        $configured_secondary = (array) $category_display['secondary_actions'];
+    }
+
+    foreach ( array_merge( $configured_secondary, $global_secondary_map ) as $action ) {
+        if ( empty( $action['meta'] ) ) {
+            continue;
+        }
+
+        $value = lbhotel_get_meta_with_fallback( $post_id, $action['meta'], '' );
+
+        if ( ! $value ) {
+            continue;
+        }
+
+        $secondary_buttons[] = array(
+            'url'   => esc_url( $value ),
+            'label' => isset( $action['label'] ) ? $action['label'] : __( 'View', 'lbhotel' ),
+            'class' => isset( $action['class'] ) ? $action['class'] : 'lbhotel-button lbhotel-button--ghost',
+        );
+    }
+
+    $location_parts = array_filter( array( $address, $city, $region, $postal_code, $country ) );
+    $location_line  = implode( ', ', array_filter( array( $city, $region, $country ) ) );
+
     ?>
     <article id="post-<?php the_ID(); ?>" <?php post_class( 'lbhotel-single-place ' . $category_class ); ?>>
         <header class="lbhotel-single-place__header">
@@ -60,74 +195,100 @@ while ( have_posts() ) :
             <?php endif; ?>
             <h1 class="lbhotel-single-place__title"><?php the_title(); ?></h1>
             <?php if ( ! empty( $category_map ) ) : ?>
-                <p class="lbhotel-single-place__categories">
-                    <?php echo esc_html( implode( ', ', $category_map ) ); ?>
-                </p>
+                <p class="lbhotel-single-place__categories"><?php echo esc_html( implode( ', ', $category_map ) ); ?></p>
             <?php endif; ?>
         </header>
 
-        <div class="lbhotel-single-place__content">
-            <div class="lbhotel-single-place__main">
-                <div class="lbhotel-single-place__description">
-                    <?php the_content(); ?>
-                </div>
-
-                <?php if ( $virtual_tour_url ) : ?>
-                    <p class="lbhotel-single-place__virtual-tour">
-                        <a class="button" href="<?php echo esc_url( $virtual_tour_url ); ?>" target="_blank" rel="noopener">
-                            <?php esc_html_e( 'Explore the virtual tour', 'lbhotel' ); ?>
-                        </a>
-                    </p>
-                <?php endif; ?>
-
-                <?php if ( ! empty( $gallery ) ) : ?>
-                    <section class="lbhotel-single-place__gallery" aria-label="<?php esc_attr_e( 'Gallery images', 'lbhotel' ); ?>">
-                        <h2><?php esc_html_e( 'Gallery', 'lbhotel' ); ?></h2>
-                        <div class="lbhotel-gallery-grid">
-                            <?php foreach ( $gallery as $image_id ) : ?>
-                                <figure class="lbhotel-gallery-grid__item">
-                                    <?php echo wp_get_attachment_image( $image_id, 'large' ); ?>
+        <div class="lbhotel-single-place__layout">
+            <section class="lbhotel-single-place__hero" aria-label="<?php esc_attr_e( 'Place highlights', 'lbhotel' ); ?>">
+                <div class="lbhotel-single-place__media" data-lbhotel-slider>
+                    <?php if ( ! empty( $gallery_urls ) ) : ?>
+                        <div class="lbhotel-single-place__slides">
+                            <?php foreach ( $gallery_urls as $index => $image_url ) : ?>
+                                <figure class="lbhotel-single-place__slide">
+                                    <img src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( get_the_title() ); ?>" />
                                 </figure>
                             <?php endforeach; ?>
                         </div>
-                    </section>
-                <?php endif; ?>
+                        <button type="button" class="lbhotel-single-place__nav lbhotel-single-place__nav--prev" aria-label="<?php esc_attr_e( 'Previous image', 'lbhotel' ); ?>">&#10094;</button>
+                        <button type="button" class="lbhotel-single-place__nav lbhotel-single-place__nav--next" aria-label="<?php esc_attr_e( 'Next image', 'lbhotel' ); ?>">&#10095;</button>
+                        <div class="lbhotel-single-place__dots" role="tablist">
+                            <?php foreach ( $gallery_urls as $index => $unused ) : ?>
+                                <button type="button" class="lbhotel-single-place__dot" aria-label="<?php echo esc_attr( sprintf( __( 'Go to image %d', 'lbhotel' ), $index + 1 ) ); ?>"></button>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php else : ?>
+                        <div class="lbhotel-single-place__placeholder" aria-hidden="true"></div>
+                    <?php endif; ?>
+                </div>
+
+                <div class="lbhotel-single-place__info">
+                    <?php if ( $rating_markup ) : ?>
+                        <div class="lbhotel-single-place__rating">
+                            <?php echo $rating_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <?php if ( $location_line ) : ?>
+                        <p class="lbhotel-single-place__location"><?php echo esc_html( $location_line ); ?></p>
+                    <?php endif; ?>
+
+                    <?php if ( ! empty( $highlights ) ) : ?>
+                        <ul class="lbhotel-single-place__highlights">
+                            <?php foreach ( $highlights as $highlight ) : ?>
+                                <li>
+                                    <?php if ( $highlight['label'] ) : ?>
+                                        <span class="lbhotel-single-place__highlight-label"><?php echo esc_html( $highlight['label'] ); ?>:</span>
+                                    <?php endif; ?>
+                                    <span class="lbhotel-single-place__highlight-value">
+                                        <?php
+                                        if ( ! empty( $highlight['multiline'] ) ) {
+                                            echo wp_kses_post( nl2br( esc_html( $highlight['value'] ) ) );
+                                        } else {
+                                            echo esc_html( $highlight['value'] );
+                                        }
+                                        ?>
+                                    </span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+
+                    <?php if ( ! empty( $primary_buttons ) || ! empty( $secondary_buttons ) ) : ?>
+                        <div class="lbhotel-single-place__actions">
+                            <?php foreach ( $primary_buttons as $button ) : ?>
+                                <a class="<?php echo esc_attr( $button['class'] ); ?>" href="<?php echo esc_url( $button['url'] ); ?>" target="_blank" rel="noopener">
+                                    <?php echo esc_html( $button['label'] ); ?>
+                                </a>
+                            <?php endforeach; ?>
+                            <?php foreach ( $secondary_buttons as $button ) : ?>
+                                <a class="<?php echo esc_attr( $button['class'] ); ?>" href="<?php echo esc_url( $button['url'] ); ?>" target="_blank" rel="noopener">
+                                    <?php echo esc_html( $button['label'] ); ?>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </section>
+
+            <div class="lbhotel-single-place__main-content">
+                <div class="lbhotel-single-place__description">
+                    <?php the_content(); ?>
+                </div>
             </div>
 
             <aside class="lbhotel-single-place__sidebar" aria-label="<?php esc_attr_e( 'Place details', 'lbhotel' ); ?>">
                 <section class="lbhotel-single-place__panel">
-                    <h2><?php esc_html_e( 'Location', 'lbhotel' ); ?></h2>
-                    <ul class="lbhotel-single-place__list">
-                        <?php if ( $location_meta['lbhotel_address'] ) : ?>
-                            <li><?php echo esc_html( $location_meta['lbhotel_address'] ); ?></li>
-                        <?php endif; ?>
-                        <?php if ( $location_meta['lbhotel_city'] ) : ?>
-                            <li><?php echo esc_html( $location_meta['lbhotel_city'] ); ?></li>
-                        <?php endif; ?>
-                        <?php if ( $location_meta['lbhotel_region'] ) : ?>
-                            <li><?php echo esc_html( $location_meta['lbhotel_region'] ); ?></li>
-                        <?php endif; ?>
-                        <?php if ( $location_meta['lbhotel_postal_code'] ) : ?>
-                            <li><?php echo esc_html( $location_meta['lbhotel_postal_code'] ); ?></li>
-                        <?php endif; ?>
-                        <?php if ( $location_meta['lbhotel_country'] ) : ?>
-                            <li><?php echo esc_html( $location_meta['lbhotel_country'] ); ?></li>
-                        <?php endif; ?>
-                    </ul>
-                    <?php if ( $location_meta['lbhotel_google_maps_url'] ) : ?>
-                        <p><a href="<?php echo esc_url( $location_meta['lbhotel_google_maps_url'] ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'View on Google Maps', 'lbhotel' ); ?></a></p>
+                    <h2><?php esc_html_e( 'Location details', 'lbhotel' ); ?></h2>
+                    <?php if ( ! empty( $location_parts ) ) : ?>
+                        <ul class="lbhotel-single-place__list">
+                            <?php foreach ( $location_parts as $part ) : ?>
+                                <li><?php echo esc_html( $part ); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
                     <?php endif; ?>
-                    <?php if ( $location_meta['lbhotel_latitude'] || $location_meta['lbhotel_longitude'] ) : ?>
-                        <dl class="lbhotel-single-place__coords">
-                            <?php if ( $location_meta['lbhotel_latitude'] ) : ?>
-                                <dt><?php esc_html_e( 'Latitude', 'lbhotel' ); ?></dt>
-                                <dd><?php echo esc_html( $location_meta['lbhotel_latitude'] ); ?></dd>
-                            <?php endif; ?>
-                            <?php if ( $location_meta['lbhotel_longitude'] ) : ?>
-                                <dt><?php esc_html_e( 'Longitude', 'lbhotel' ); ?></dt>
-                                <dd><?php echo esc_html( $location_meta['lbhotel_longitude'] ); ?></dd>
-                            <?php endif; ?>
-                        </dl>
+                    <?php if ( $map_url ) : ?>
+                        <p><a class="lbhotel-button lbhotel-button--ghost" href="<?php echo esc_url( $map_url ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'View on map', 'lbhotel' ); ?></a></p>
                     <?php endif; ?>
                 </section>
 
@@ -138,46 +299,25 @@ while ( have_posts() ) :
                     </section>
                 <?php endif; ?>
 
-                <?php foreach ( $category_map as $slug => $label ) :
-                    $fields_for_category = lbhotel_get_fields_for_category( $slug );
-                    $category_values     = array();
-
-                    foreach ( $fields_for_category as $meta_key => $definition ) {
-                        $value = get_post_meta( $post_id, $meta_key, true );
-
-                        if ( '' === $value || empty( $value ) ) {
-                            continue;
-                        }
-
-                        $category_values[] = array(
-                            'label' => $definition['label'],
-                            'value' => $value,
-                            'input' => isset( $definition['input'] ) ? $definition['input'] : 'text',
-                        );
-                    }
-
-                    if ( empty( $category_values ) ) {
-                        continue;
-                    }
-                    ?>
+                <?php if ( ! empty( $details ) ) : ?>
                     <section class="lbhotel-single-place__panel">
-                        <h2><?php echo esc_html( sprintf( __( '%s details', 'lbhotel' ), $label ) ); ?></h2>
+                        <h2><?php esc_html_e( 'Key details', 'lbhotel' ); ?></h2>
                         <dl class="lbhotel-single-place__details">
-                            <?php foreach ( $category_values as $detail ) : ?>
+                            <?php foreach ( $details as $detail ) : ?>
                                 <dt><?php echo esc_html( $detail['label'] ); ?></dt>
                                 <dd>
                                     <?php
-                                    if ( 'url' === $detail['input'] ) {
-                                        echo '<a href="' . esc_url( $detail['value'] ) . '" target="_blank" rel="noopener">' . esc_html( $detail['value'] ) . '</a>';
+                                    if ( ! empty( $detail['multiline'] ) ) {
+                                        echo wp_kses_post( nl2br( esc_html( $detail['value'] ) ) );
                                     } else {
-                                        echo nl2br( esc_html( $detail['value'] ) );
+                                        echo esc_html( $detail['value'] );
                                     }
                                     ?>
                                 </dd>
                             <?php endforeach; ?>
                         </dl>
                     </section>
-                <?php endforeach; ?>
+                <?php endif; ?>
             </aside>
         </div>
     </article>


### PR DESCRIPTION
## Summary
- introduce helper utilities to read Virtual Maroc meta keys with legacy fallbacks and render ratings
- add category-level display configuration with vm_rating field and shared templates showing dynamic fields
- provide shared styling and slider script so all place categories reuse the same layout on single and archive pages

## Testing
- php -l includes/helpers.php
- php -l includes/place-fields.php
- php -l templates/shared/single-place.php
- php -l templates/shared/all-places.php

------
https://chatgpt.com/codex/tasks/task_e_68e577cb57188324a0221112afe844e3