### PR TITLE
Rename plugin to Virtual Maroc and remove template footers

### DIFF
--- a/admin/css/lbhotel-admin.css
+++ b/admin/css/lbhotel-admin.css
@@ -1,4 +1,4 @@
-/* Admin styles for Le Bon Hotel */
+/* Admin styles for Virtual Maroc */
 
 .lbhotel-gallery-field {
     border: 1px solid #ccd0d4;

--- a/includes/admin-meta.php
+++ b/includes/admin-meta.php
@@ -2,7 +2,7 @@
 /**
  * Admin meta boxes and meta registration.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin-notices.php
+++ b/includes/admin-notices.php
@@ -2,7 +2,7 @@
 /**
  * Admin notice helpers.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -2,7 +2,7 @@
 /**
  * Asset registration and enqueueing.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/class-lbhotel-import-export.php
+++ b/includes/class-lbhotel-import-export.php
@@ -2,7 +2,7 @@
 /**
  * Import and export tools for Virtual Maroc places.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Helper utilities for Le Bon Hotel.
+ * Helper utilities for Virtual Maroc.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/place-fields.php
+++ b/includes/place-fields.php
@@ -2,7 +2,7 @@
 /**
  * Field configuration for Virtual Maroc places.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -2,7 +2,7 @@
 /**
  * Custom post type registration.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -2,7 +2,7 @@
 /**
  * REST API endpoints for Virtual Maroc places.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Settings page for Le Bon Hotel.
+ * Settings page for Virtual Maroc.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -175,7 +175,7 @@ function lbhotel_render_settings_page() {
     );
 
     echo '<div class="wrap">';
-    echo '<h1>' . esc_html__( 'Le Bon Hotel Settings', 'lbhotel' ) . '</h1>';
+    echo '<h1>' . esc_html__( 'Virtual Maroc Settings', 'lbhotel' ) . '</h1>';
 
     echo '<form action="options.php" method="post">';
     settings_fields( 'lbhotel_settings_group' );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Shortcode registration for hotel listings.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/taxonomies.php
+++ b/includes/taxonomies.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Taxonomy registration for Le Bon Hotel.
+ * Taxonomy registration for Virtual Maroc.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/templates.php
+++ b/includes/templates.php
@@ -2,7 +2,7 @@
 /**
  * Template helpers for Virtual Maroc places.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/le-bon-hotel.php
+++ b/le-bon-hotel.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Plugin Name:       Le Bon Hotel
- * Plugin URI:        https://example.com/le-bon-hotel
+ * Plugin Name:       Virtual Maroc
+ * Plugin URI:        https://example.com/virtual-maroc
  * Description:       Complete hotel directory toolkit for managing listings, booking information, and showcasing hotels on the front end.
  * Version:           1.0.0
- * Author:            Le Bon Plugins
+ * Author:            Virtual Maroc Plugins
  * Author URI:        https://example.com
  * Text Domain:       lbhotel
  * Domain Path:       /languages
  * Requires at least: 5.8
  * Requires PHP:      7.4
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/migrations/migrate-restaurants.php
+++ b/migrations/migrate-restaurants.php
@@ -2,7 +2,7 @@
 /**
  * Migration helpers from the legacy restaurant plugin.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/public/css/lbhotel.css
+++ b/public/css/lbhotel.css
@@ -1,5 +1,5 @@
 /*
- * Front-end styles for Le Bon Hotel.
+ * Front-end styles for Virtual Maroc.
  * Palette: Navy #1b3b5f, Gold #d4a017, Light Gray #f5f7fa.
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Le Bon Hotel ===
+=== Virtual Maroc ===
 Contributors: lebonplugins
 Requires at least: 5.8
 Tested up to: 6.4
@@ -7,7 +7,7 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Le Bon Hotel transforms WordPress into a hotel directory complete with REST API integration, booking widgets, and beautiful front-end listings.
+Virtual Maroc transforms WordPress into a hotel directory complete with REST API integration, booking widgets, and beautiful front-end listings.
 
 == Description ==
 
@@ -36,7 +36,7 @@ Fetch hotels with `GET /wp-json/lbhotel/v1/hotels`. Example response schema:
 ```
 {
   "id": 42,
-  "title": "Le Bon Hotel Central",
+  "title": "Virtual Maroc Central",
   "permalink": "https://example.com/hotel/le-bon-hotel-central",
   "star_rating": 4,
   "currency": "MAD",
@@ -60,4 +60,4 @@ The `lbhotel_migrate_from_restaurant()` helper maps restaurant meta (address, ra
 
 == Uninstall ==
 
-Removing the plugin through the WordPress UI deletes plugin options and custom metadata created by Le Bon Hotel.
+Removing the plugin through the WordPress UI deletes plugin options and custom metadata created by Virtual Maroc.

--- a/shortcodes/list.php
+++ b/shortcodes/list.php
@@ -5,7 +5,7 @@
  * @var WP_Query $query Query with hotels.
  * @var array    $atts  Shortcode attributes.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! isset( $query ) || ! $query instanceof WP_Query ) {

--- a/shortcodes/single.php
+++ b/shortcodes/single.php
@@ -4,7 +4,7 @@
  *
  * @var WP_Post $post The hotel post.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! isset( $post ) || ! $post instanceof WP_Post ) {

--- a/templates/Cultural Events/all-events.php
+++ b/templates/Cultural Events/all-events.php
@@ -2,7 +2,7 @@
 /**
  * Cultural events archive template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Cultural Events/single-event.php
+++ b/templates/Cultural Events/single-event.php
@@ -2,7 +2,7 @@
 /**
  * Cultural events single template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Hotels/all-hotels.php
+++ b/templates/Hotels/all-hotels.php
@@ -2,7 +2,7 @@
 /**
  * Hotels archive template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Hotels/single-hotel.php
+++ b/templates/Hotels/single-hotel.php
@@ -2,7 +2,7 @@
 /**
  * Hotel single template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Recreational Activities/all-activities.php
+++ b/templates/Recreational Activities/all-activities.php
@@ -2,7 +2,7 @@
 /**
  * Recreational activities archive template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Recreational Activities/single-activity.php
+++ b/templates/Recreational Activities/single-activity.php
@@ -2,7 +2,7 @@
 /**
  * Recreational activities single template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Restaurants/all-restaurants.php
+++ b/templates/Restaurants/all-restaurants.php
@@ -2,7 +2,7 @@
 /**
  * Restaurants archive template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Restaurants/single-restaurant.php
+++ b/templates/Restaurants/single-restaurant.php
@@ -2,7 +2,7 @@
 /**
  * restaurants single template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Shopping/all-shops.php
+++ b/templates/Shopping/all-shops.php
@@ -2,7 +2,7 @@
 /**
  * Shopping archive template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Shopping/single-shop.php
+++ b/templates/Shopping/single-shop.php
@@ -2,7 +2,7 @@
 /**
  * Shopping single template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Sports Activities/all-sports.php
+++ b/templates/Sports Activities/all-sports.php
@@ -2,7 +2,7 @@
 /**
  * Sports activities archive template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Sports Activities/single-sport.php
+++ b/templates/Sports Activities/single-sport.php
@@ -2,7 +2,7 @@
 /**
  * Sports activities single template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Tourist Sites/all-sites.php
+++ b/templates/Tourist Sites/all-sites.php
@@ -2,7 +2,7 @@
 /**
  * Tourist sites archive template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/Tourist Sites/single-site.php
+++ b/templates/Tourist Sites/single-site.php
@@ -2,7 +2,7 @@
 /**
  * Tourist sites single template loader.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/shared/all-places.php
+++ b/templates/shared/all-places.php
@@ -2,7 +2,7 @@
 /**
  * Archive template for Virtual Maroc places.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -570,6 +570,3 @@ get_header();
         <?php if ( function_exists( 'astra_sidebar_primary' ) ) { astra_sidebar_primary(); } ?>
     </div>
 </div>
-
-<?php
-get_footer();

--- a/templates/shared/single-place.php
+++ b/templates/shared/single-place.php
@@ -2,7 +2,7 @@
 /**
  * Shared single template for Virtual Maroc places.
  *
- * @package LeBonHotel
+ * @package VirtualMaroc
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -390,5 +390,3 @@ $script_localized = false;
         <?php endwhile; ?>
     </main>
 </div>
-<?php
-get_footer();

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Uninstall cleanup for Le Bon Hotel.
+ * Uninstall cleanup for Virtual Maroc.
  */
 
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {


### PR DESCRIPTION
## Summary
- rename plugin metadata and documentation from Le Bon Hotel to Virtual Maroc
- update settings screen heading to use the new name
- stop loading the theme footer in shared archive and single templates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e65d6bc13083249bf809d34bc24873